### PR TITLE
Draft updates 2

### DIFF
--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -29,7 +29,7 @@ contract Delegation is EIP712, GuardedExecutor {
     /// @dev The type of key.
     enum KeyType {
         P256,
-        WebAuthnP256, 
+        WebAuthnP256,
         Secp256k1
     }
 
@@ -40,7 +40,7 @@ contract Delegation is EIP712, GuardedExecutor {
         /// @dev Type of key. See the {KeyType} enum.
         KeyType keyType;
         /// @dev Whether the key is a super admin key.
-        /// Super admin keys are allowed to call into super admin functions such as 
+        /// Super admin keys are allowed to call into super admin functions such as
         /// `authorize` and `revoke` via `execute`.
         bool isSuperAdmin;
         /// @dev Public key in encoded form.
@@ -389,9 +389,7 @@ contract Delegation is EIP712, GuardedExecutor {
             );
         } else if (key.keyType == KeyType.Secp256k1) {
             isValid = SignatureCheckerLib.isValidSignatureNowCalldata(
-                abi.decode(key.publicKey, (address)), 
-                digest,
-                signature
+                abi.decode(key.publicKey, (address)), digest, signature
             );
         }
     }

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -177,6 +177,10 @@ contract EntryPoint is EIP712, UUPSUpgradeable, Ownable, ReentrancyGuard {
         virtual
         returns (UserOpStatus[] memory statuses)
     {
+        // We'll use assembly for the following benefits:
+        // - Avoid quadratic memory expansion costs.
+        //   We don't want userOps at the end to be unfairly subjected to more gas costs.
+        // - Avoid unnecessary memory copying.
         assembly ("memory-safe") {
             statuses := mload(0x40)
             mstore(statuses, encodedUserOps.length) // Store length of `statuses`.
@@ -192,6 +196,7 @@ contract EntryPoint is EIP712, UUPSUpgradeable, Ownable, ReentrancyGuard {
                 // This chunk of code prepares the variables and also
                 // carefully verifies that `encodedUserOps` has been properly encoded,
                 // such that no nested dynamic types (i.e. UserOp, bytes) are out of bounds.
+                // If you are reading for high-level understanding, ignore this part.
                 {
                     let t :=
                         add(encodedUserOps.offset, calldataload(add(encodedUserOps.offset, shl(5, i))))
@@ -220,8 +225,10 @@ contract EntryPoint is EIP712, UUPSUpgradeable, Ownable, ReentrancyGuard {
                 }
 
                 for {} 1 {} {
+                    // 1. Pay.
                     mstore(m, 0xcc1d5274) // `_payEntryPoint()`.
                     mstore(0x00, 0) // Zeroize the return slot.
+                    // Ensure that `userOp.paymentAmount <= userOp.paymentMaxAmount`.
                     if gt(
                         calldataload(add(u, _USER_OP_PAYMENT_AMOUNT_POS)),
                         calldataload(add(u, _USER_OP_PAYMENT_MAX_AMOUNT_POS))
@@ -229,12 +236,15 @@ contract EntryPoint is EIP712, UUPSUpgradeable, Ownable, ReentrancyGuard {
                         mstore(add(add(0x20, statuses), shl(5, i)), 3) // `PaymentFailure`.
                         break
                     }
+                    // Perform a gas-limited call and check for success.
                     let g := calldataload(add(u, _USER_OP_PAYMENT_GAS_POS)) // `paymentGas`.
                     // This returns `(bool success)`.
                     if iszero(and(eq(1, mload(0x00)), call(g, address(), 0, s, n, 0x00, 0x20))) {
                         mstore(add(add(0x20, statuses), shl(5, i)), 3) // `PaymentFailure`.
                         break
                     }
+
+                    // 2. Verify.
                     mstore(m, 0xbaf2bed9) // `_verify()`.
                     mstore(0x00, 0) // Zeroize the return slot.
                     g := calldataload(add(u, _USER_OP_VERIFICATION_GAS_POS)) // `verificationGas`.
@@ -243,6 +253,8 @@ contract EntryPoint is EIP712, UUPSUpgradeable, Ownable, ReentrancyGuard {
                         mstore(add(add(0x20, statuses), shl(5, i)), 2) // `VerificationFailure`.
                         break
                     }
+
+                    // 3. Execute.
                     mstore(m, 0x420aadb8) // `_execute()`.
                     mstore(add(m, 0x20), mload(0x20)) // Copy the `keyHash` over.
                     mstore(0x00, 0) // Zeroize the return slot.
@@ -399,7 +411,9 @@ contract EntryPoint is EIP712, UUPSUpgradeable, Ownable, ReentrancyGuard {
         }
         address paymentRecipient = userOp.paymentRecipient;
         if (paymentRecipient != address(0)) {
-            TokenTransferLib.safeTransferFrom(paymentToken, address(this), paymentRecipient, paymentAmount);
+            TokenTransferLib.safeTransferFrom(
+                paymentToken, address(this), paymentRecipient, paymentAmount
+            );
             // Double check, in case that ERC20 is some token with baked in fees on transfer.
             if (TokenTransferLib.balanceOf(paymentToken, address(this)) < tokenBalanceBefore) {
                 revert EntryPointPaymentFailed();

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -181,6 +181,10 @@ contract EntryPoint is EIP712, UUPSUpgradeable, Ownable, ReentrancyGuard {
         // - Avoid quadratic memory expansion costs.
         //   We don't want userOps at the end to be unfairly subjected to more gas costs.
         // - Avoid unnecessary memory copying.
+        // - I might one day rewrite this in a normie-friendly version for readability,
+        //   but will still recommend using the assembloored version.
+        //   In terms of performance, assembly will likely yield much greater benefits
+        //   aggregated signatures.
         assembly ("memory-safe") {
             statuses := mload(0x40)
             mstore(statuses, encodedUserOps.length) // Store length of `statuses`.

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -405,9 +405,10 @@ contract GuardedExecutor is ERC7821 {
         if (period == SpendPeriod.Day) return unixTimestamp / 86400 * 86400;
         if (period == SpendPeriod.Week) return DateTimeLib.mondayTimestamp(unixTimestamp);
         (uint256 year, uint256 month,) = DateTimeLib.timestampToDate(unixTimestamp);
+        // Note: DateTimeLib's months and month-days start from 1.
         if (period == SpendPeriod.Month) return DateTimeLib.dateToTimestamp(year, month, 1);
         if (period == SpendPeriod.Year) return DateTimeLib.dateToTimestamp(year, 1, 1);
-        return unixTimestamp;
+        revert(); // We shouldn't hit here.
     }
 
     ////////////////////////////////////////////////////////////////////////

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -173,7 +173,7 @@ contract GuardedExecutor is ERC7821 {
             address token = spends.tokens.at(i);
             if (token != address(0)) {
                 t.erc20s.p(token);
-                t.transferAmounts.p(uint256(0));    
+                t.transferAmounts.p(uint256(0));
             }
         }
 

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -210,9 +210,7 @@ contract GuardedExecutor is ERC7821 {
                 t.permit2Spenders.p(LibBytes.loadCalldata(data, 0x24)); // `spender`.
             }
         }
-        if (totalNativeSpend != 0) {
-            _incrementSpent(spends.spends[address(0)], totalNativeSpend);
-        }
+        _incrementSpent(spends.spends[address(0)], totalNativeSpend);
 
         // Sum transfer amounts, grouped by the ERC20s. In-place.
         LibSort.groupSum(t.erc20s.data, t.transferAmounts.data);
@@ -437,6 +435,7 @@ contract GuardedExecutor is ERC7821 {
 
     /// @dev Increments the amount spent.
     function _incrementSpent(TokenSpendStorage storage s, uint256 amount) internal {
+        if (amount == uint256(0)) return; // Early return.
         uint256 n = s.periods.length();
         for (uint256 i; i < n; ++i) {
             uint8 period = s.periods.at(i);

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -2,10 +2,30 @@
 pragma solidity ^0.8.23;
 
 import {ERC7821} from "solady/accounts/ERC7821.sol";
+import {LibSort} from "solady/utils/LibSort.sol";
 import {LibBytes} from "solady/utils/LibBytes.sol";
 import {LibBit} from "solady/utils/LibBit.sol";
+import {DynamicArrayLib} from "solady/utils/DynamicArrayLib.sol";
+import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
+import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
+import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
 
 contract GuardedExecutor is ERC7821 {
+    using DynamicArrayLib for *;
+    using EnumerableSetLib for *;
+
+    ////////////////////////////////////////////////////////////////////////
+    // Structs
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev Information about a daily spend.
+    struct DailySpendInfo {
+        address token;
+        uint256 limit;
+        uint256 spent;
+        uint256 lastUpdatedDay;
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Errors
     ////////////////////////////////////////////////////////////////////////
@@ -19,12 +39,25 @@ contract GuardedExecutor is ERC7821 {
     /// @dev Unauthorized to perform the action.
     error Unauthorized();
 
+    /// @dev Exceeded the daily spend limit.
+    error ExceededDailySpendLimit();
+
+    /// @dev Cannot add a new daily spend, as we have reached the maximum capacity.
+    /// This is required to prevent unbounded checking costs during execution.
+    error ExceededDailySpendsCapacity();
+
     ////////////////////////////////////////////////////////////////////////
     // Events
     ////////////////////////////////////////////////////////////////////////
 
     /// @dev Emitted when the ability to execute a call with function selector is set.
     event CanExecuteSet(bytes32 keyHash, address target, bytes4 fnSel, bool can);
+
+    /// @dev Emitted when a daily spend limit is set.
+    event DailySpendLimitSet(bytes32 keyHash, address token, uint256 limit);
+
+    /// @dev Emitted when a daily spend limit is removed.
+    event DailySpendLimitRemoved(bytes32 keyHash, address token);
 
     ////////////////////////////////////////////////////////////////////////
     // Constants
@@ -45,14 +78,33 @@ contract GuardedExecutor is ERC7821 {
     /// and we will use this special value to denote empty calldata.
     bytes4 public constant EMPTY_CALLDATA_FN_SEL = 0xe0e0e0e0;
 
+    /// @dev The canonical Permit2 address.
+    address internal constant _PERMIT2 = 0x000000000022D473030F116dDEE9F6B43aC78BA3;
+
     ////////////////////////////////////////////////////////////////////////
     // Storage
     ////////////////////////////////////////////////////////////////////////
 
+    /// @dev Holds the storage for the daily spend limits.
+    struct DailySpendStorage {
+        uint256 limit;
+        uint256 spent;
+        uint256 lastUpdatedDay;
+    }
+
+    /// @dev Holds the storage for spend permissions and the current spend state.
+    struct SpendStorage {
+        EnumerableSetLib.AddressSet tokens;
+        mapping(address => DailySpendStorage) dailys;
+    }
+
     /// @dev Holds the storage.
     struct GuardedExecutorStorage {
-        /// @dev Mapping of a call hash to whether it can be executed.
+        /// @dev Mapping of `keccak256(abi.encodePacked(keyHash, target, fnSel))`
+        /// to whether it can be executed.
         mapping(bytes32 => bool) canExecute;
+        /// @dev Mapping of `keyHash` to the `SpendStorage`.
+        mapping(bytes32 => SpendStorage) spends;
     }
 
     /// @dev Returns the storage pointer.
@@ -71,6 +123,100 @@ contract GuardedExecutor is ERC7821 {
     ////////////////////////////////////////////////////////////////////////
     // ERC7821
     ////////////////////////////////////////////////////////////////////////
+
+    struct _ExecuteTemps {
+        DynamicArrayLib.DynamicArray withApprovals;
+        DynamicArrayLib.DynamicArray approvalTos;
+        DynamicArrayLib.DynamicArray erc20s;
+        DynamicArrayLib.DynamicArray transferAmounts;
+        DynamicArrayLib.DynamicArray guardedERC20s;
+        uint256[] balancesBefore;
+        uint256 totalNativeSpend;
+    }
+
+    /// @dev The `_execute` function imposes daily spending limits with the following:
+    /// 1. For every token with a daily spending limit, the
+    ///    `max(sum(outgoingAmounts), balanceBefore - balanceAfter)`
+    ///    will be added to the daily spent limit.
+    /// 2. Any token that is granted a non-zero approval will have the approval
+    ///    reset to zero after the calls.
+    function _execute(Call[] calldata calls, bytes32 keyHash) internal virtual override {
+        if (keyHash == 0) {
+            return ERC7821._execute(calls, keyHash);
+        }
+
+        SpendStorage storage spends = _getGuardedExecutorStorage().spends[keyHash];
+        _ExecuteTemps memory t;
+
+        unchecked {
+            uint256 n = spends.tokens.length();
+            for (uint256 i; i != n; ++i) {
+                address token = spends.tokens.at(i);
+                if (token != address(0)) {
+                    t.erc20s.p(token);
+                    t.transferAmounts.p(uint256(0));
+                }
+                t.guardedERC20s = t.erc20s.copy();
+            }
+        }
+        // We will only filter based on functions that are known to use `msg.sender`.
+        // For signature-based approvals (e.g. permit), we can't do anything
+        // to guard, as anyone else can directly submit the calldata and the signature.
+        for (uint256 i; i != calls.length; i = FixedPointMathLib.rawAdd(i, 1)) {
+            (address target, uint256 value, bytes calldata data) = _get(calls, i);
+            t.totalNativeSpend += value;
+            if (data.length < 4) continue;
+            bytes4 fnSel = bytes4(LibBytes.loadCalldata(data, 0x00));
+            // `transfer(address,uint256)`.
+            if (fnSel == 0xa9059cbb && t.guardedERC20s.contains(target)) {
+                t.erc20s.p(target);
+                t.transferAmounts.p(LibBytes.loadCalldata(data, 0x24));
+            }
+            // `approve(address,uint256)`.
+            if (fnSel == 0x095ea7b3 && t.guardedERC20s.contains(target)) {
+                if (LibBytes.loadCalldata(data, 0x24) != 0) {
+                    t.withApprovals.p(target);
+                    t.approvalTos.p(LibBytes.loadCalldata(data, 0x04));
+                }
+            }
+            // The only Permit2 method that requires `msg.sender` to approve.
+            // `approve(address,address,uint160,uint48)`.
+            if (target == _PERMIT2 && fnSel == 0x87517c45) revert Unauthorized();
+        }
+        _incrementSpent(spends.dailys[address(0)], t.totalNativeSpend);
+
+        // Sum transfer amounts, grouped by erc20s.
+        LibSort.groupSum(t.erc20s.data, t.transferAmounts.data);
+
+        t.balancesBefore = DynamicArrayLib.malloc(t.erc20s.length());
+        unchecked {
+            for (uint256 i; i != t.erc20s.length(); ++i) {
+                address token = t.erc20s.getAddress(i);
+                t.balancesBefore.set(i, SafeTransferLib.balanceOf(token, address(this)));
+            }
+        }
+
+        // Perform the batch execution.
+        ERC7821._execute(calls, keyHash);
+
+        unchecked {
+            // Revoke all non-zero approvals that have been made.
+            for (uint256 i; i < t.withApprovals.length(); ++i) {
+                SafeTransferLib.safeApprove(
+                    t.withApprovals.getAddress(i), t.approvalTos.getAddress(i), 0
+                );
+            }
+            // Increments the spent amounts.
+            for (uint256 i; i < t.erc20s.length(); ++i) {
+                address token = t.erc20s.getAddress(i);
+                uint256 delta = FixedPointMathLib.zeroFloorSub(
+                    t.balancesBefore.get(i), SafeTransferLib.balanceOf(token, address(this))
+                );
+                delta = FixedPointMathLib.max(delta, t.transferAmounts.get(i));
+                _incrementSpent(spends.dailys[token], delta);
+            }
+        }
+    }
 
     /// @dev Override to add a check on `keyHash`.
     function _execute(address target, uint256 value, bytes calldata data, bytes32 keyHash)
@@ -111,6 +257,27 @@ contract GuardedExecutor is ERC7821 {
         emit CanExecuteSet(keyHash, target, fnSel, can);
     }
 
+    /// @dev Sets the daily spend limit of `token` for `keyHash`.
+    function setDailySpendLimit(bytes32 keyHash, address token, uint256 limit)
+        public
+        virtual
+        onlyThis
+    {
+        SpendStorage storage spends = _getGuardedExecutorStorage().spends[keyHash];
+        spends.tokens.add(token);
+        if (spends.tokens.length() > 255) revert ExceededDailySpendsCapacity();
+        spends.dailys[token].limit = limit;
+        emit DailySpendLimitSet(keyHash, token, limit);
+    }
+
+    /// @dev Removes the daily spend limit of `token` for `keyHash`.
+    function removeDailySpendLimit(bytes32 keyHash, address token) public virtual onlyThis {
+        SpendStorage storage spends = _getGuardedExecutorStorage().spends[keyHash];
+        spends.tokens.remove(token);
+        delete spends.dailys[token];
+        emit DailySpendLimitRemoved(keyHash, token);
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Public View Functions
     ////////////////////////////////////////////////////////////////////////
@@ -129,11 +296,11 @@ contract GuardedExecutor is ERC7821 {
         mapping(bytes32 => bool) storage c = _getGuardedExecutorStorage().canExecute;
 
         bytes4 fnSel = ANY_FN_SEL;
-        
+
         // If the calldata has 4 or more bytes, we can assume that the leading 4 bytes
-        // denotes the function selector. 
+        // denotes the function selector.
         if (data.length >= 4) fnSel = bytes4(LibBytes.loadCalldata(data, 0x00));
-        
+
         // If the calldata is empty, make sure that the empty calldata has been authorized.
         if (data.length == uint256(0)) fnSel = EMPTY_CALLDATA_FN_SEL;
 
@@ -152,6 +319,26 @@ contract GuardedExecutor is ERC7821 {
         return false;
     }
 
+    /// @dev Returns an array containing information on all the daily spends for `keyHash`.
+    function dailySpends(bytes32 keyHash)
+        public
+        view
+        virtual
+        returns (DailySpendInfo[] memory results)
+    {
+        SpendStorage storage spends = _getGuardedExecutorStorage().spends[keyHash];
+        results = new DailySpendInfo[](spends.tokens.length());
+        for (uint256 i; i < results.length; ++i) {
+            DailySpendInfo memory info = results[i];
+            address token = spends.tokens.at(i);
+            info.token = token;
+            DailySpendStorage storage daily = spends.dailys[token];
+            info.limit = daily.limit;
+            info.spent = daily.spent;
+            info.lastUpdatedDay = daily.lastUpdatedDay;
+        }
+    }
+
     ////////////////////////////////////////////////////////////////////////
     // Internal Helpers
     ////////////////////////////////////////////////////////////////////////
@@ -161,7 +348,7 @@ contract GuardedExecutor is ERC7821 {
         return LibBit.and(target == address(this), fnSel == ERC7821.execute.selector);
     }
 
-    /// @dev Returns the hash of function.
+    /// @dev Returns `keccak256(abi.encodePacked(keyHash, target, fnSel))`.
     function _hash(bytes32 keyHash, address target, bytes4 fnSel)
         internal
         pure
@@ -174,6 +361,16 @@ contract GuardedExecutor is ERC7821 {
             mstore(0x04, keyHash)
             result := keccak256(0x00, 0x38) // 4 + 20 + 32 = 56 = 0x38.
         }
+    }
+
+    /// @dev Increments the amount spent.
+    function _incrementSpent(DailySpendStorage storage daily, uint256 amount) internal virtual {
+        uint256 currentDay = block.timestamp / 86400;
+        if (daily.lastUpdatedDay < currentDay) {
+            daily.lastUpdatedDay = currentDay;
+            daily.spent = 0;
+        }
+        if ((daily.spent += amount) > daily.limit) revert ExceededDailySpendLimit();
     }
 
     /// @dev Guards a function such that it can only be called by `address(this)`.


### PR DESCRIPTION
- ERC20 and native token spend permissions.

Todo:
- Write tests.
- EntryPoint create2 address.
- Ability to let delegation approve more than one EntryPoint (tied to current delegation codehash). This allows for the delegation to possibly switch to a more performant, but abi equivalent EntryPoint in the future.

Thoughts:
- The EntryPoint is quite a complex beast, due to it's need for gas introspection and performance, just like the 4337 EntryPoint. I think in the end state, a good EntryPoint will be written in very optimized inline-assembly. Also, the main bottleneck in Base's gas costs by far is L2 gas.