### PR TITLE
fix: Fix incorrect variable usage in inner loop

### DIFF
--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -373,7 +373,7 @@ contract GuardedExecutor is ERC7821 {
             TokenSpendStorage storage tokenSpends = spends.spends[token];
             uint8[] memory periods = tokenSpends.periods.values();
             for (uint256 j; j < periods.length; ++j) {
-                uint8 period = periods[i];
+                uint8 period = periods[j];
                 TokenPeriodSpendStorage storage tokenPeriodSpend = tokenSpends.spends[period];
                 SpendInfo memory info;
                 info.period = SpendPeriod(period);


### PR DESCRIPTION
Inside the inner `for` loop, the variable `i` was mistakenly used instead of `j` to access elements of the `periods` array. 
This caused incorrect behavior since `i` is already used in the outer loop.  

Changes made:  
- Replaced `periods[i]` with `periods[j]` to ensure proper access to the array elements.  
