### PR TITLE
fix: Fixed broken link to Foundry config in foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,6 @@
 # Foundry Configuration File
 # Default definitions: https://github.com/gakonst/foundry/blob/b7917fa8491aedda4dd6db53fbb206ea233cd531/config/src/lib.rs#L782
-# See more config options at: https://github.com/gakonst/foundry/tree/master/config
+# See more config options at: https://github.com/foundry-rs/foundry/tree/master/.config.
 
 # The Default Profile
 [profile.default]


### PR DESCRIPTION
The link to the Foundry config documentation was pointing to an outdated URL.
I updated it to the correct one: `https://github.com/foundry-rs/foundry/tree/master/.config`.

**This should help users access the right resources without confusion.**