### PR TITLE
fix: prevent division by zero in _brutalizeMemory()

### DIFF
--- a/test/utils/Brutalizer.sol
+++ b/test/utils/Brutalizer.sol
@@ -33,6 +33,9 @@ contract Brutalizer {
             r := mulmod(mload(0x10), _LPRNG_MULTIPLIER, _LPRNG_MODULO)
 
             let cSize := add(codesize(), iszero(codesize()))
+
+            if eq(cSize, 0) { cSize := 1 }
+
             if iszero(lt(cSize, 32)) { cSize := sub(cSize, and(mload(0x02), 0x1f)) }
             let start := mod(mload(0x10), cSize)
             let size := mul(sub(cSize, start), gt(cSize, start))


### PR DESCRIPTION
Added a safety check to ensure `cSize` is never zero in `_brutalizeMemory()`.  
This prevents potential division by zero errors when calculating `mod(mload(0x10), cSize)`,  
which could cause unexpected behavior in memory brutalization tests.

Changes:
- Added `if eq(cSize, 0) { cSize := 1 }` to `_brutalizeMemory()`.