### PR TITLE
Tidy and optimize

### DIFF
--- a/script/UpgradeDelegation.s.sol
+++ b/script/UpgradeDelegation.s.sol
@@ -17,7 +17,7 @@ contract UpgradeDelegationScript is Script {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
         // address deployer = vm.createWallet(deployerPrivateKey).addr;
         address proxy = 0xF9a8529Bb95ac7707129700f06343338E4767A27;
-        address newImplementation = 0x23165b46bee38d6FeCfC50f57c29F1035cA10B0F;
+        address newImplementation = 0xa12767Cada47951f79772d673e53a84133537c87;
         vm.startBroadcast(deployerPrivateKey);
         IEIP7702ProxyWithAdminABI(proxy).upgrade(newImplementation);
         vm.stopBroadcast();

--- a/script/UpgradeEntryPoint.s.sol
+++ b/script/UpgradeEntryPoint.s.sol
@@ -12,11 +12,10 @@ contract UpgradeEntryPointScript is Script {
         address deployer = vm.createWallet(deployerPrivateKey).addr;
         ERC1967Factory erc1967Factory = ERC1967Factory(ERC1967FactoryConstants.ADDRESS);
         address proxy = 0x307AF7d28AfEE82092aA95D35644898311CA5360;
-        address newImplementation = 0x904176a23Ca0C5Cc7e796F754Be809d57a129E30;
+        address newImplementation = 0x417C61a18f3e89fD27A073f3351De6783D182860;
+        bytes memory initializeOwnerData = abi.encodeWithSignature("_initializeOwner()", deployer);
         vm.startBroadcast(deployerPrivateKey);
-        erc1967Factory.upgradeAndCall(
-            proxy, newImplementation, abi.encodeWithSignature("_initializeOwner()", deployer)
-        );
+        erc1967Factory.upgradeAndCall(proxy, newImplementation, "");
         vm.stopBroadcast();
     }
 }

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -12,7 +12,6 @@ import {P256} from "solady/utils/P256.sol";
 import {WebAuthn} from "solady/utils/WebAuthn.sol";
 import {LibStorage} from "solady/utils/LibStorage.sol";
 import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
-import {CallContextChecker} from "solady/utils/CallContextChecker.sol";
 import {GuardedExecutor} from "./GuardedExecutor.sol";
 import {TokenTransferLib} from "./TokenTransferLib.sol";
 
@@ -362,7 +361,7 @@ contract Delegation is EIP712, GuardedExecutor {
     }
 
     /// @dev Computes the EIP712 digest for `calls`, with `nonceSalt` from storage.
-    /// If the nonce is odd, the digest will be computed without the chain ID.
+    /// If the nonce is odd, the digest will be computed without the chain ID and with a zero nonce salt.
     /// Otherwise, the digest will be computed with the chain ID.
     function computeDigest(Call[] calldata calls, uint256 nonce)
         public
@@ -388,7 +387,7 @@ contract Delegation is EIP712, GuardedExecutor {
             nonce & 1,
             uint256(a.hash()),
             nonce,
-            _getDelegationStorage().nonceSalt
+            nonce & 1 > 0 ? 0 : _getDelegationStorage().nonceSalt
         );
         return nonce & 1 > 0 ? _hashTypedDataSansChainId(structHash) : _hashTypedData(structHash);
     }

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -18,7 +18,7 @@ import {TokenTransferLib} from "./TokenTransferLib.sol";
 
 /// @title Delegation
 /// @notice A delegation contract for EOAs with EIP7702.
-contract Delegation is EIP712, GuardedExecutor, CallContextChecker {
+contract Delegation is EIP712, GuardedExecutor {
     using EfficientHashLib for bytes32[];
     using EnumerableSetLib for *;
     using LibBytes for LibBytes.BytesStorage;
@@ -538,7 +538,6 @@ contract Delegation is EIP712, GuardedExecutor, CallContextChecker {
         if (!$.approvedImplementations.contains(target)) {
             revert Unauthorized();
         }
-        _checkOnlyEIP7702Authority();
         if (msg.sender != address(this)) {
             if (!_getApprovedImplementationCallers(target).contains(msg.sender)) {
                 revert Unauthorized();

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -402,7 +402,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
     }
 
     /// @dev Computes the EIP712 digest for the UserOp.
-    /// If the nonce is odd, the digest will be computed without the chain ID.
+    /// If the nonce is odd, the digest will be computed without the chain ID and with a zero nonce salt.
     /// Otherwise, the digest will be computed with the chain ID.
     function _computeDigest(UserOp calldata u) internal view virtual returns (bytes32) {
         bytes32[] calldata pointers = LibERC7579.decodeBatch(u.executionData);
@@ -428,7 +428,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
         f.set(2, uint160(u.eoa));
         f.set(3, a.hash());
         f.set(4, u.nonce);
-        f.set(5, _nonceSalt(u.eoa));
+        f.set(5, u.nonce & 1 > 0 ? 0 : _nonceSalt(u.eoa));
         f.set(6, uint160(u.payer));
         f.set(7, uint160(u.paymentToken));
         f.set(8, u.paymentMaxAmount);

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -57,10 +57,6 @@ contract GuardedExecutor is ERC7821 {
     /// @dev Exceeded the daily spend limit.
     error ExceededSpendLimit();
 
-    /// @dev Cannot add a new daily spend, as we have reached the maximum capacity.
-    /// This is required to prevent unbounded checking costs during execution.
-    error ExceededSpendsCapacity();
-
     ////////////////////////////////////////////////////////////////////////
     // Events
     ////////////////////////////////////////////////////////////////////////
@@ -293,12 +289,10 @@ contract GuardedExecutor is ERC7821 {
         checkKeyHashIsNonZero(keyHash)
     {
         SpendStorage storage spends = _getGuardedExecutorStorage().spends[keyHash];
-        spends.tokens.add(token);
-        if (spends.tokens.length() >= 64) revert ExceededSpendsCapacity();
+        spends.tokens.add(token, 64); // Max capacity of 64.
 
         TokenSpendStorage storage tokenSpends = spends.spends[token];
         tokenSpends.periods.add(uint8(period));
-        if (tokenSpends.periods.length() >= 8) revert ExceededSpendsCapacity();
 
         tokenSpends.spends[uint8(period)].limit = limit;
         emit SpendLimitSet(keyHash, token, period, limit);

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -353,12 +353,12 @@ contract GuardedExecutor is ERC7821 {
         if (_isSelfExecute(target, fnSel)) if (!_isSuperAdmin(keyHash)) return false;
 
         if (c[_hash(keyHash, target, fnSel)]) return true;
-        if (c[_hash(keyHash, ANY_TARGET, fnSel)]) return true;
-        if (c[_hash(ANY_KEYHASH, target, fnSel)]) return true;
-        if (c[_hash(ANY_KEYHASH, ANY_TARGET, fnSel)]) return true;
         if (c[_hash(keyHash, target, ANY_FN_SEL)]) return true;
+        if (c[_hash(keyHash, ANY_TARGET, fnSel)]) return true;
         if (c[_hash(keyHash, ANY_TARGET, ANY_FN_SEL)]) return true;
+        if (c[_hash(ANY_KEYHASH, target, fnSel)]) return true;
         if (c[_hash(ANY_KEYHASH, target, ANY_FN_SEL)]) return true;
+        if (c[_hash(ANY_KEYHASH, ANY_TARGET, fnSel)]) return true;
         if (c[_hash(ANY_KEYHASH, ANY_TARGET, ANY_FN_SEL)]) return true;
         return false;
     }

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -8,7 +8,7 @@ import {LibBit} from "solady/utils/LibBit.sol";
 import {DynamicArrayLib} from "solady/utils/DynamicArrayLib.sol";
 import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
-import {FixedPointMathLib} from "solady/utils/FixedPointMathLib.sol";
+import {FixedPointMathLib as Math} from "solady/utils/FixedPointMathLib.sol";
 import {DateTimeLib} from "solady/utils/DateTimeLib.sol";
 
 contract GuardedExecutor is ERC7821 {
@@ -231,9 +231,8 @@ contract GuardedExecutor is ERC7821 {
             uint256 balance = SafeTransferLib.balanceOf(token, address(this));
             _incrementSpent(
                 spends.spends[token],
-                FixedPointMathLib.max(
-                    t.transferAmounts.get(i),
-                    FixedPointMathLib.zeroFloorSub(balancesBefore.get(i), balance)
+                Math.max(
+                    t.transferAmounts.get(i), Math.saturatingSub(balancesBefore.get(i), balance)
                 )
             );
         }
@@ -398,9 +397,9 @@ contract GuardedExecutor is ERC7821 {
         pure
         returns (uint256)
     {
-        if (period == SpendPeriod.Minute) return unixTimestamp / 60 * 60;
-        if (period == SpendPeriod.Hour) return unixTimestamp / 3600 * 3600;
-        if (period == SpendPeriod.Day) return unixTimestamp / 86400 * 86400;
+        if (period == SpendPeriod.Minute) return Math.rawMul(Math.rawDiv(unixTimestamp, 60), 60);
+        if (period == SpendPeriod.Hour) return Math.rawMul(Math.rawDiv(unixTimestamp, 3600), 3600);
+        if (period == SpendPeriod.Day) return Math.rawMul(Math.rawDiv(unixTimestamp, 86400), 86400);
         if (period == SpendPeriod.Week) return DateTimeLib.mondayTimestamp(unixTimestamp);
         (uint256 year, uint256 month,) = DateTimeLib.timestampToDate(unixTimestamp);
         // Note: DateTimeLib's months and month-days start from 1.


### PR DESCRIPTION
- [x] Make multichain hashes use zero nonce salt. This is required, otherwise calling `invalidateNonceSalt` once will make multichain hashes unreplayable across all chains.
- [x] Remove `_checkOnlyEIP7702Authority`. As the implementation will be a smart contract without an secp256k1 key, there is no way for the delegatecall mode to be invoked directly on the implementation. Hence, this check is not needed.
- [x] Rearrange checks in `canExecute`, from most likely to least likely. This helps save gas on average.
- [x] Use capped add for `EnumerableSetLib` in `GuardedExecutor`. Remove the need to define an extra custom error just for this.