### PR TITLE
♻️ Refactor EntryPoint nonces

### DIFF
--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -64,6 +64,8 @@ contract Delegation is EIP712, GuardedExecutor {
     struct DelegationStorage {
         /// @dev The label.
         LibBytes.BytesStorage label;
+        /// @dev Reserved spacer.
+        uint256 _spacer0;
         /// @dev Mapping for 4337-style 2D nonce sequences.
         /// Each nonce has the following bit layout:
         /// - Upper 192 bits are used for the `seqKey` (sequence key).
@@ -71,7 +73,6 @@ contract Delegation is EIP712, GuardedExecutor {
         ///   then the UserOp EIP-712 hash will exclude the chain ID.
         /// - Lower 64 bits are used for the sequential nonce corresponding to the `seqKey`.
         mapping(uint192 => LibStorage.Ref) nonceSeqs;
-        uint256 _spacer0;
         /// @dev Set of key hashes for onchain enumeration of authorized keys.
         EnumerableSetLib.Bytes32Set keyHashes;
         /// @dev Mapping of key hash to the key in encoded form.

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -564,7 +564,6 @@ contract Delegation is EIP712, GuardedExecutor {
         // Entry point workflow.
         if (msg.sender == ENTRY_POINT) {
             if (opData.length < 0x40) revert OpDataTooShort();
-            _useNonce(uint256(LibBytes.loadCalldata(opData, 0x00)));
             return _execute(calls, LibBytes.loadCalldata(opData, 0x20));
         }
 

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -527,7 +527,7 @@ contract Delegation is EIP712, GuardedExecutor {
         // Entry point workflow.
         if (msg.sender == ENTRY_POINT) {
             if (opData.length < 0x20) revert OpDataTooShort();
-            return _execute(calls, LibBytes.loadCalldata(opData, 0x20));
+            return _execute(calls, LibBytes.loadCalldata(opData, 0x00));
         }
 
         // Simple workflow without `opData`.

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -139,7 +139,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
     /// @dev Holds the storage.
     struct EntryPointStorage {
         mapping(address => mapping(uint192 => uint64)) accountsNonce;
-        mapping(address => mapping(uint256 => bytes4)) errMsg;
+        mapping(address => mapping(uint256 => bytes32)) errMsg;
         LibBitmap.Bitmap filledOrderIds;
     }
 

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -197,34 +197,30 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
         nonReentrant
         returns (bytes4[] memory errs)
     {
-        // Allocate memory for `errs` without zeroizing it.
-        assembly ("memory-safe") {
-            errs := mload(0x40) // Grab the free memory pointer.
-            mstore(errs, encodedUserOps.length) // Store the length.
-            mstore(0x40, add(add(0x20, errs), shl(5, encodedUserOps.length))) // Allocate.
-        }
-        for (uint256 i; i != encodedUserOps.length;) {
+        // This allocation and loop was initially in assembly, but I've normified it for now.
+        errs = new bytes4[](encodedUserOps.length);
+        for (uint256 i; i < encodedUserOps.length; ++i) {
             // We reluctantly use regular Solidity to access `encodedUserOps[i]`.
             // This generates an unnecessary check for `i < encodedUserOps.length`, but helps
             // generate all the implicit calldata bound checks on `encodedUserOps[i]`.
-            (, bytes4 err) = _execute(encodedUserOps[i]);
-            // Set `errs[i]` without bounds checks.
-            assembly ("memory-safe") {
-                i := add(i, 1) // Increment `i` here so we don't need `add(errs, 0x20)`.
-                mstore(add(errs, shl(5, i)), err)
-            }
+            (, errs[i]) = _execute(encodedUserOps[i]);
         }
     }
 
     /// @dev This function does not actually execute. It simulates an execution
     /// and reverts with the amount of gas used, and the error selector.
-    function simulateExecute(bytes calldata encodedUserOp) public payable virtual {
+    function simulateExecute(bytes calldata encodedUserOp) public payable virtual nonReentrant {
         (uint256 gUsed, bytes4 err) = _execute(encodedUserOp);
         revert SimulationResult(gUsed, err);
     }
 
     /// @dev This function is provided for debugging purposes.
-    function simulateFailedVerifyAndCall(bytes calldata encodedUserOp) public payable virtual {
+    function simulateFailedVerifyAndCall(bytes calldata encodedUserOp)
+        public
+        payable
+        virtual
+        nonReentrant
+    {
         UserOp calldata u = _extractUserOp(encodedUserOp);
         (bool isValid, bytes32 keyHash) = _verify(u);
         if (!isValid) revert VerificationError();
@@ -244,8 +240,8 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
             let t := calldataload(encodedUserOp.offset)
             u := add(t, encodedUserOp.offset)
             // Bounds check. We don't need to explicitly check the fields here.
-            // In the self call functions, we will use regular Solidity to access the fields,
-            // which generate the implicit bounds checks.
+            // In the self call functions, we will use regular Solidity to access the
+            // dynamic fields like `signature`, which generate the implicit bounds checks.
             if or(shr(64, t), lt(encodedUserOp.length, 0x20)) { revert(0x00, 0x00) }
         }
     }
@@ -279,6 +275,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
             // Even if the verify and call fails, which the gas will be burned,
             // the payment has already been made and can't be reverted.
 
+            // We'll use assembly for frequently used call related stuff to save massive memory gas.
             for {} iszero(err) {} {
                 let m := mload(0x40) // Grab the free memory pointer.
                 // Copy the encoded user op to the memory to be ready to pass to the self call.
@@ -398,32 +395,16 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
                 revert OrderAlreadyFilled();
             }
         }
-        // `originData` is encoded as:
-        // `abi.encode(bytes(encodedUserOp), address(fundingToken), uint256(fundingAmount))`.
-        bytes calldata encodedUserOp;
-        address fundingToken;
-        uint256 fundingAmount;
-        address eoa;
-        // We have to do this cuz Solidity does not have a `abi.validateEncoding`.
-        // `abi.decode` is very inefficient, allocating and copying memory needlessly.
-        // Also, `execute` takes in a `bytes calldata`, so we can't use `abi.decode` here.
-        assembly ("memory-safe") {
-            fundingToken := calldataload(add(originData.offset, 0x20))
-            fundingAmount := calldataload(add(originData.offset, 0x40))
-            let s := calldataload(originData.offset)
-            let t := add(originData.offset, s)
-            encodedUserOp.length := calldataload(t)
-            encodedUserOp.offset := add(t, 0x20)
-            let e := add(originData.offset, originData.length)
-            // Bounds checks.
-            if or(
-                or(shr(64, or(s, t)), or(lt(originData.length, 0x60), lt(s, 0x60))),
-                gt(add(encodedUserOp.length, encodedUserOp.offset), e)
-            ) { revert(0x00, 0x00) }
-            eoa := calldataload(add(encodedUserOp.offset, calldataload(encodedUserOp.offset)))
-        }
+        // This entire `abi.decode` was initially written in assembly, but I've normified
+        // it for now so that reviewers won't get too distracted by assembly noise.
+        // `abi.decode` is extremely wasteful, but yeah, readability.
+        // Plus I think ERC7683 crosschain filling won't be used that often
+        // (also not sure if this is the best high-level approach in the long term).
+        (bytes memory encodedUserOp, address fundingToken, uint256 fundingAmount) =
+            abi.decode(originData, (bytes, address, uint256));
+        address eoa = abi.decode(encodedUserOp, (UserOp)).eoa;
         TokenTransferLib.safeTransferFrom(fundingToken, msg.sender, eoa, fundingAmount);
-        return execute(encodedUserOp);
+        return this.execute(encodedUserOp);
     }
 
     /// @dev Returns true if the order ID has been filled.
@@ -502,8 +483,10 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
     /// On failure, bubbles up the revert if required, or reverts with `CallError()`.
     function _execute(UserOp calldata u, bytes32 keyHash, bool bubbleRevert) internal virtual {
         // This re-encodes the ERC7579 `executionData` with the optional `opData`.
+        // We expect that the delegation supports ERC7821
+        // (an extension of ERC7579 tailored for 7702 accounts).
         bytes memory data = LibERC7579.reencodeBatchAsExecuteCalldata(
-            0x0100000000007821000100000000000000000000000000000000000000000000,
+            0x0100000000007821000100000000000000000000000000000000000000000000, // ERC7821 batch execution mode.
             u.executionData,
             abi.encode(keyHash) // `opData`.
         );
@@ -584,7 +567,6 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
         // `_verifyAndCall()`.
         if (s == 0xe235a92a) {
             require(msg.sender == address(this));
-
             (bool isValid, bytes32 keyHash) = _verify(u);
             if (!isValid) revert VerificationError();
             _execute(u, keyHash, false);

--- a/test/EntryPoint.t.sol
+++ b/test/EntryPoint.t.sol
@@ -65,7 +65,7 @@ contract EntryPointTest is SoladyTest {
                 t.targetFunctionPayloads[i].value = _bound(_random(), 0, 2 ** 32 - 1),
                 t.targetFunctionPayloads[i].data = _truncateBytes(_randomBytes(), 0xff)
             );
-            u.nonce = ep.getAccountNonce(u.eoa, 0);
+            u.nonce = ep.getNonce(u.eoa, 0);
             paymentToken.mint(u.eoa, 2 ** 128 - 1);
             u.paymentToken = address(paymentToken);
             u.paymentAmount = _bound(_random(), 0, 2 ** 32 - 1);
@@ -300,6 +300,8 @@ contract EntryPointTest is SoladyTest {
         bytes memory data = abi.encodeWithSignature("execute(bytes)", abi.encode(userOp));
         address _ep = address(ep);
         bytes4 err;
+        uint256 startBalance = address(0xbcde).balance;
+
         uint256 g = gasleft();
         assembly {
             pop(call(gas(), _ep, 0, add(data, 0x20), mload(data), 0x00, 0x20))
@@ -307,39 +309,22 @@ contract EntryPointTest is SoladyTest {
             err := mload(0)
         }
 
-        uint256 startBalance = address(0xbcde).balance;
-
-        data = abi.encodeWithSignature("execute(bytes)", abi.encode(userOp));
-        g = gasleft();
-
-        assembly {
-            pop(call(gas(), _ep, 0, add(data, 0x20), mload(data), 0x00, 0x20))
-            g := sub(g, gas())
-            err := mload(0)
-        }
-        vm.breakpoint("a");
-
         // paymentReceipt get paid enough pays for reverted tx
-        assertGt((address(0xbcde).balance - startBalance), g);
+        assertGt((address(0xbcde).balance - startBalance), g / 2);
         assertEq(EntryPoint.VerifiedCallError.selector, err);
-
-        bytes32 slot0 = keccak256(
-            abi.encode(
-                0,
-                keccak256(
-                    abi.encode(
-                        aliceAddress, uint72(bytes9(keccak256("PORTO_ENTRY_POINT_STORAGE"))) + 1
-                    )
-                )
-            )
-        );
-
-        bytes32 errMsg = vm.load(address(ep), slot0);
+        (, err) = ep.nonceStatus(aliceAddress, userOp.nonce);
+        assertEq(EntryPoint.VerifiedCallError.selector, err);
 
         startBalance = address(0xbcde).balance;
 
         // Run out of gas at _call time
-        userOp.combinedGas = 50000;
+        userOp.nonce++;
+        userOp.executionData = _getExecutionData(
+            address(paymentToken),
+            0,
+            abi.encodeWithSignature("transfer(address,uint256)", address(0x11111), 1 ether)
+        );
+        userOp.combinedGas = 25000;
         _fillSecp256k1Signature(userOp, alice, bytes32(0x00));
         data = abi.encodeWithSignature("execute(bytes)", abi.encode(userOp));
 
@@ -350,23 +335,12 @@ contract EntryPointTest is SoladyTest {
             err := mload(0)
         }
         // paymentReceipt get paid enough pays for reverted tx
-        assertGt((address(0xbcde).balance - startBalance), g);
+        assertGt((address(0xbcde).balance - startBalance), g / 2);
         assertEq(EntryPoint.CallError.selector, err);
-        bytes32 slot = keccak256(
-            abi.encode(
-                0,
-                keccak256(
-                    abi.encode(
-                        aliceAddress, uint72(bytes9(keccak256("PORTO_ENTRY_POINT_STORAGE"))) + 1
-                    )
-                )
-            )
-        );
+        (, err) = ep.nonceStatus(aliceAddress, userOp.nonce);
+        assertEq(EntryPoint.CallError.selector, err);
 
-        errMsg = vm.load(address(ep), slot);
-        assertEq(EntryPoint.CallError.selector, errMsg);
-
-        ep.getAccountNonce(aliceAddress, 0);
+        ep.getNonce(aliceAddress, 0);
     }
 
     function testExecuteWithPayingERC20TokensWithRefund(bytes32) public {
@@ -419,7 +393,7 @@ contract EntryPointTest is SoladyTest {
         assertEq(paymentToken.balanceOf(address(this)), actualAmount);
         // extra goes back to signer
         assertEq(paymentToken.balanceOf(randomSigner), 500 ether - actualAmount - 1 ether);
-        assertEq(ep.getAccountNonce(randomSigner, 0), 1);
+        assertEq(ep.getNonce(randomSigner, 0), 1);
     }
 
     function testExecuteBatchCalls(uint256 n) public {
@@ -472,7 +446,7 @@ contract EntryPointTest is SoladyTest {
 
         for (uint256 i; i < n; ++i) {
             assertEq(errs[i], bytes4(0x0000000));
-            assertEq(ep.getAccountNonce(signer[i], 0), 1);
+            assertEq(ep.getNonce(signer[i], 0), 1);
         }
         assertEq(paymentToken.balanceOf(address(0xabcd)), n * 0.5 ether);
     }
@@ -530,7 +504,7 @@ contract EntryPointTest is SoladyTest {
         assertEq(
             paymentToken.balanceOf(signer), 100 ether - (0.5 ether * n + (gUsed + 50000) * 1e9)
         );
-        assertEq(ep.getAccountNonce(signer, 0), 1);
+        assertEq(ep.getNonce(signer, 0), 1);
     }
 
     function testExceuteRevertWithIfPayAmountIsLittle() public {
@@ -605,7 +579,7 @@ contract EntryPointTest is SoladyTest {
                 t.targetFunctionPayload.value = _bound(_random(), 0, 2 ** 32 - 1),
                 t.targetFunctionPayload.data = _truncateBytes(_randomBytes(), 0xff)
             );
-            u.nonce = ep.getAccountNonce(u.eoa, 0);
+            u.nonce = ep.getNonce(u.eoa, 0);
             paymentToken.mint(address(this), 2 ** 128 - 1);
             paymentToken.approve(address(ep), 2 ** 128 - 1);
             t.fundingToken = address(paymentToken);


### PR DESCRIPTION
Rationale:

Right now, the EntryPoint nonce system is in the Delegation. This means that when a transaction fails, the ERC20 payment is actually made, but the nonce isn't consumed. This is dangerous, since the signed userop can be abused to drain the ERC20 of the eoa.

This PR does 3 things.

1. Move the EntryPoint nonce system to the EntryPoint itself. This means if a UserOp fails, the nonce will still be consumed.

2. Change the nonce style to be a 4337-style 2D nonce [more info](https://hackmd.io/@atarpara/BkU-NNz5yl). 
 - Previously, we can invalidate all the unused signatures by simply incrementing `nonceSalt`. This 2D nonce system does not have `nonceSalt`. This means to invalidate all the unused signatures, one must take note of all the `keySeq` (i.e. the upper 192 bits that have been signed), and invalidate them one-by-one.
 - For out-of-order nonces, just make the `keySeq` pseudorandom. I have yet to determine a way to mass invalidate nonces across `keySeq`s.
3. On UserOp failure, record the `err` for the nonce in storage.
```
storageSlot = keccak256(
    abi.encode(
        (userOp.nonce >> 64),
        keccak256(
            abi.encode(
                userOp.eoa,
                uint72(bytes9(keccak256("PORTO_ENTRY_POINT_STORAGE"))) + 1
            )
        )
    )
);
```

- [x] Added sequential nonce increment for each eoa
- [x] Remove `_useNonce` from delegation.sol for `entryPoint`
- [x] Fix Entrypoint Test