### PR TITLE
fix: call `_initializeOwnerData()` on entrypoint upgrade

### DIFF
--- a/script/UpgradeEntryPoint.s.sol
+++ b/script/UpgradeEntryPoint.s.sol
@@ -15,7 +15,7 @@ contract UpgradeEntryPointScript is Script {
         address newImplementation = 0xcaC83d258BAA181b686bA7b3f6FCD0FCF75d5082;
         bytes memory initializeOwnerData = abi.encodeWithSignature("_initializeOwner()", deployer);
         vm.startBroadcast(deployerPrivateKey);
-        erc1967Factory.upgradeAndCall(proxy, newImplementation, "");
+        erc1967Factory.upgradeAndCall(proxy, newImplementation, initializeOwnerData);
         vm.stopBroadcast();
     }
 }


### PR DESCRIPTION
This previously left the entrypoint proxy in a non-upgradeable state which broke my entrypoint deployment