### PR TITLE
Refactor payEntryPoint to compensate

### DIFF
--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -426,14 +426,16 @@ contract Delegation is EIP712, GuardedExecutor {
     // Entry Point Functions
     ////////////////////////////////////////////////////////////////////////
 
-    /// @dev Pays `paymentAmount` of `paymentToken` to the Entry Point.
-    function payEntryPoint(address paymentToken, uint256 paymentAmount, address eoa)
-        public
-        virtual
-    {
+    /// @dev Pays `paymentAmount` of `paymentToken` to the `paymentRecipient`.
+    function compensate(
+        address paymentToken,
+        address paymentRecipient,
+        uint256 paymentAmount,
+        address eoa
+    ) public virtual {
         if (msg.sender != ENTRY_POINT) revert Unauthorized();
         if (eoa != address(this)) revert Unauthorized();
-        TokenTransferLib.safeTransfer(paymentToken, msg.sender, paymentAmount);
+        TokenTransferLib.safeTransfer(paymentToken, paymentRecipient, paymentAmount);
     }
 
     /// @dev Returns if the signature is valid, along with its `keyHash`.

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -462,13 +462,12 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
         }
         assembly ("memory-safe") {
             let m := mload(0x40) // Cache the free memory pointer.
-            mstore(0x00, 0x887f7d7c) // `payEntryPoint(address,uint256,address)`.
-            mstore(0x20, shr(96, shl(96, paymentToken)))
-            mstore(0x40, paymentAmount)
-            mstore(0x60, shr(96, shl(96, eoa)))
-            pop(call(gas(), payer, 0, 0x1c, 0x64, 0x00, 0x00))
-            mstore(0x40, m) // Restore the free memory pointer.
-            mstore(0x60, 0) // Restore the zero pointer.
+            mstore(m, 0x56298c98) // `compensate(address,address,uint256,address)`.
+            mstore(add(m, 0x20), shr(96, shl(96, paymentToken)))
+            mstore(add(m, 0x40), address())
+            mstore(add(m, 0x60), paymentAmount)
+            mstore(add(m, 0x80), shr(96, shl(96, eoa)))
+            pop(call(gas(), payer, 0, add(m, 0x1c), 0x84, 0x00, 0x00))
         }
         if (TokenTransferLib.balanceOf(paymentToken, address(this)) < requiredBalanceAfter) {
             revert PaymentError();


### PR DESCRIPTION
This will allow the optimization for the case where `paymentPerGas == 0` or `paymentPerGas == type(uint256).max`.

For this special case, we can directly pay the desired recipient and skip the entire refund workflow.

I think in the end game, where there is sufficient incentives for relayers to pay exact gas, this optimization can become favorable.

This should not be a breaking change unless you need to access the specific ERC20 transfer events.