### PR TITLE
Refactor compensate

### DIFF
--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -472,6 +472,8 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
             // The UserOp can be retrieved via assembly: `userOp := add(0x84, calldataload(0x84))`.
             // This pattern is extremely efficient, as it avoids unnecessary decoding of UserOp args.
             // It is also extremely flexible, allowing multiple variants of UserOps to be supported.
+            // Additionally, `encodedUserOp` can be abused to add additional data, e.g.:
+            // `encodedUserOp = abi.encode(userOp, someCustomStructForThePayer)`.
             let n := sub(calldatasize(), 0x04)
             calldatacopy(add(m, 0xa0), 0x04, n)
             pop(call(gas(), payer, 0, add(m, 0x1c), add(0x84, n), 0x00, 0x00))

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -467,14 +467,14 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
             mstore(add(m, 0x40), address())
             mstore(add(m, 0x60), paymentAmount)
             mstore(add(m, 0x80), shr(96, shl(96, eoa)))
-            // Copy the entire `UserOp` to the end of the calldata, in case `payer` needs
+            // Copy the entire `encodedUserOp` to the end of the calldata, in case `payer` needs
             // bespoke logic to validate the payment.
-            // The UserOp can be easily retrieved via assembly: `userOp := 0x84`.
+            // The UserOp can be retrieved via assembly: `userOp := add(0x84, calldataload(0x84))`.
             // This pattern is extremely efficient, as it avoids unnecessary decoding of UserOp args.
             // It is also extremely flexible, allowing multiple variants of UserOps to be supported.
-            let n := sub(calldatasize(), u)
-            calldatacopy(add(m, 0xa0), u, n)
-            pop(call(gas(), payer, 0, add(m, 0x1c), add(0x84, u), 0x00, 0x00))
+            let n := sub(calldatasize(), 0x04)
+            calldatacopy(add(m, 0xa0), 0x04, n)
+            pop(call(gas(), payer, 0, add(m, 0x1c), add(0x84, n), 0x00, 0x00))
         }
         if (TokenTransferLib.balanceOf(paymentToken, address(this)) < requiredBalanceAfter) {
             revert PaymentError();


### PR DESCRIPTION
Allows 3rd party custom paymasters to do fancy validation logic.

```solidity
    /// @dev Pays `paymentAmount` of `paymentToken` to the `paymentRecipient`.
    function compensate(
        address paymentToken,
        address paymentRecipient,
        uint256 paymentAmount,
        address eoa
    ) public virtual {
        assembly {
            let userOp := add(0x84, calldataload(0x84))
            if xor(shl(96, eoa), shl(96, calldataload(userOp))) { invalid() }
        }
        if (msg.sender != ENTRY_POINT) revert Unauthorized();
        if (eoa != address(this)) revert Unauthorized();
        TokenTransferLib.safeTransfer(paymentToken, paymentRecipient, paymentAmount);
    }
```