### PR TITLE
Make EntryPoint actually bubble up the error if it is small

### DIFF
--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -595,12 +595,21 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
         address eoa = u.eoa;
         assembly ("memory-safe") {
             if iszero(call(gas(), eoa, 0, add(0x20, data), mload(data), 0x00, 0x00)) {
-                if iszero(bubbleRevert) {
-                    mstore(0x00, 0x6c9d47e8) // `CallError()`.
-                    revert(0x1c, 0x04)
+                // If `bubbleRevert` is true, just bubble up the entire revert,
+                // this is for `simulateFailedVerifyAndCall`.
+                if bubbleRevert {
+                    returndatacopy(mload(0x40), 0x00, returndatasize())
+                    revert(mload(0x40), returndatasize())
                 }
-                returndatacopy(mload(0x40), 0x00, returndatasize())
-                revert(mload(0x40), returndatasize())
+                // If the reverted returndata fits within a single word.
+                if iszero(gt(returndatasize(), 0x1f)) {
+                    returndatacopy(mload(0x40), 0x00, returndatasize())
+                    // And if it is not `bytes4(0)`, revert it with.
+                    if shr(224, mload(0x40)) { revert(mload(0x40), returndatasize()) }
+                }
+                // Else, just revert with `CallError()
+                mstore(0x00, 0x6c9d47e8) // `CallError()`.
+                revert(0x1c, 0x04)
             }
         }
     }


### PR DESCRIPTION
The reason i didn’t bubble up the whole error by default, and replace it with a generic `CallError` was that it’s to prevent someone from griefing the EntryPoint by making the returndata some crazy big amount.

But i realized that if it’s just a regular 4-byte error, we can safely bubble it up.