### PR TITLE
Verification agnostic gas estimation

### DIFF
--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -257,7 +257,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
             }
 
             // Tell `simulateExecute` that we want the simulation to pass even
-            // if the signature is invalid.
+            // if the signature is invalid. Also use `type(uint64).max` as the gas limit.
             sstore(_COMBINED_GAS_OVERRIDE_SLOT, or(shl(254, 1), 0xffffffffffffffffffffffff))
             if iszero(callSimulateExecute(gas(), data)) { revertSimulateExecute2Failed() }
             gUsed := mload(0x04)
@@ -350,6 +350,8 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
             // via the 63/64 rule. This is for gas estimation. If the total amount of gas
             // for the whole transaction is insufficient, revert.
             if (((gasleft() * 63) >> 6) < Math.saturatingAdd(g, _INNER_GAS_OVERHEAD)) {
+                // Don't revert if the bit at `1 << 254` is set. For `simulateExecute2` to be able to
+                // get a simulation before knowing how much gas is needed without reverting.
                 if ((combinedGasOverride >> 254) & 1 == 0) revert InsufficientGas();
             }
             if ((combinedGasOverride >> 255) & 1 != 0) return (0, 0);

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -261,7 +261,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
 
             // Setting the bit at `1 << 254` tells `_execute` that we want the
             // simulation to skip the invalid signature revert and also the 63/64 rule revert.
-            // Also use `2**96 - 1` as the `combinedGas` for the very first guess.
+            // Also use `2**96 - 1` as the `combinedGas` for the very first call to `_execute`.
             sstore(_COMBINED_GAS_OVERRIDE_SLOT, or(shl(254, 1), 0xffffffffffffffffffffffff))
             if iszero(callSimulateExecute(gas(), data)) { revertSimulateExecute2Failed() }
             gUsed := mload(0x04)

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -354,6 +354,8 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
                 // get a simulation before knowing how much gas is needed without reverting.
                 if ((combinedGasOverride >> 254) & 1 == 0) revert InsufficientGas();
             }
+            // If the bit at `1 << 255` is set, this means `simulateExecute2` just wants
+            // to check the 63/64 rule, so early return to skip the rest of the computations.
             if ((combinedGasOverride >> 255) & 1 != 0) return (0, 0);
 
             // Verify and invalidate the nonce.

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -257,7 +257,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
             }
 
             // Tell `simulateExecute` that we want the simulation to pass even
-            // if the signature is invalid. Also use `type(uint64).max` as the gas limit.
+            // if the signature is invalid. Also use `2**96 - 1` as the gas limit.
             sstore(_COMBINED_GAS_OVERRIDE_SLOT, or(shl(254, 1), 0xffffffffffffffffffffffff))
             if iszero(callSimulateExecute(gas(), data)) { revertSimulateExecute2Failed() }
             gUsed := mload(0x04)

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -259,7 +259,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
                 revert(0x1c, 0x04)
             }
 
-            // Setting the bit at `1 << 254` tells `simulateExecute` that we want the
+            // Setting the bit at `1 << 254` tells `_execute` that we want the
             // simulation to skip the invalid signature revert and also the 63/64 rule revert.
             // Also use `2**96 - 1` as the `combinedGas` for the very first guess.
             sstore(_COMBINED_GAS_OVERRIDE_SLOT, or(shl(254, 1), 0xffffffffffffffffffffffff))
@@ -286,7 +286,8 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
                     if iszero(callSimulateExecute(gas(), data)) { revertSimulateExecute2Failed() }
                     if iszero(mload(0x24)) { break } // If `err` is zero, we've found the `gCombined`.
                 }
-                // Tell `_execute` to early return, as we just want to test the 63/64 rule.
+                // Setting the `1 << 255` bit tells `_execute` to early return,
+                // as we just want to test the 63/64 rule on `gExecute` for the given `gCombined`.
                 sstore(_COMBINED_GAS_OVERRIDE_SLOT, or(shl(255, 1), gCombined))
                 for { gExecute := gCombined } 1 {} {
                     gExecute := add(gExecute, shr(5, gExecute)) // Heuristic: multiply by 1.03125.


### PR DESCRIPTION
So that we don't need to go thru all those signature guessing stuff.

This PR still simulates the gas burn from the signature validation, but it avoids reverting if the signature is invalid. This allows the relay to simulate the guarded executor overhead for the particular `keyHash`, without needing a proper signature from that `keyHash`.

