### PR TITLE
docs: fix function name

### DIFF
--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -118,7 +118,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
     error SimulateExecuteFailed();
 
     /// @dev No revert has been encountered.
-    error NoRevertEncoutered();
+    error NoRevertEncountered();
 
     ////////////////////////////////////////////////////////////////////////
     // Events
@@ -366,7 +366,7 @@ contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTrans
         (bool isValid, bytes32 keyHash) = _verify(u);
         if (!isValid) revert VerificationError();
         _execute(u, keyHash, true);
-        revert NoRevertEncoutered();
+        revert NoRevertEncountered();
     }
 
     /// @dev Extracts the UserOp from the calldata bytes, with minimal checks.

--- a/test/EntryPoint.t.sol
+++ b/test/EntryPoint.t.sol
@@ -209,7 +209,7 @@ contract EntryPointTest is BaseTest {
         assertEq(ep.getNonce(d.eoa, 0), 1);
     }
 
-    function testExceuteRevertsIfPaymentIsInsufficient() public {
+    function testExecuteRevertsIfPaymentIsInsufficient() public {
         DelegatedEOA memory d = _randomEIP7702DelegatedEOA();
 
         paymentToken.mint(d.eoa, 500 ether);
@@ -279,7 +279,7 @@ contract EntryPointTest is BaseTest {
         vm.stopPrank();
     }
 
-    function testExceuteGasUsed() public {
+    function testExecuteGasUsed() public {
         uint256 n = 7;
         bytes[] memory encodeUserOps = new bytes[](n);
 


### PR DESCRIPTION
This PR fixes a typo in the error handling where "NoRevertEncountered" was incorrectly written as "NoRevertEncotered" in multiple places:

- Fixed typo in src/EntryPoint.sol error declaration
- Fixed typo in revert statement in execution flow
- Updated corresponding test files to match the corrected error name

The fix ensures consistent error naming throughout the codebase.