### PR TITLE
fix: move invariant settings under profile.default for config compliance

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -16,7 +16,7 @@ line_length = 100 # While we allow up to 120, we lint at 100 for readability.
 [profile.default.fuzz]
 runs = 256
 
-[invariant]
+[profile.default.invariant]
 depth = 15
 runs = 10
 


### PR DESCRIPTION
Problem

The invariant Foundry's efficiency is defined as a top-level section, which could lead to:

-Splitting the integrity of the configuration data.
-Making profile-based customizations (like CI/CD) difficult.
-Risk of incompatibility with Foundry's versions or tools.

Solution
By nesting the `[invariant]` software under `[profile.default]`:

-Added conformance to the standard.
-Added structural stability.
-Added flexibility for profile-based customizations.