### PR TITLE
Add intra batch spend limit detection for GuardedExecutor

### DIFF
--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -246,7 +246,8 @@ contract GuardedExecutor is ERC7821 {
             if (fnSel == 0x598daac4) {
                 if (target != address(this)) continue;
                 if (LibBytes.loadCalldata(data, 0x04) != keyHash) continue;
-                t.erc20s.p(LibBytes.loadCalldata(data, 0x24)); // `token`.
+                address token = address(uint160(uint256(LibBytes.loadCalldata(data, 0x24))));
+                t.erc20s.p(token); // `token`.
                 t.transferAmounts.p(uint256(0));
             }
         }

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -188,6 +188,8 @@ contract GuardedExecutor is ERC7821 {
     /// 2. Any token that is granted a non-zero approval will have the approval
     ///    reset to zero after the calls.
     /// 3. The spend limits are only incremented and checked against at the end of a batch.
+    /// 4. If there are calls to `setSpendLimit` or `removeSpendLimit`, the final spend limits at
+    ///    the end of the batch will be applied. Calls to `removeSpendLimit` will reset the spent.
     /// Note: Called internally in ERC7821, which coalesce zero-address `target`s to `address(this)`.
     function _execute(Call[] calldata calls, bytes32 keyHash) internal virtual override {
         // If self-execute, don't care about the spend permissions.

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -188,7 +188,7 @@ contract GuardedExecutor is ERC7821 {
     /// 2. Any token that is granted a non-zero approval will have the approval
     ///    reset to zero after the calls.
     /// 3. The spend limits are only incremented and checked against at the end of a batch.
-    /// 4. If there are calls to `setSpendLimit` or `removeSpendLimit`, the final spend limits at
+    ///    If there are calls to `setSpendLimit` or `removeSpendLimit`, the final spend limits at
     ///    the end of the batch will be applied. Calls to `removeSpendLimit` will reset the spent.
     /// Note: Called internally in ERC7821, which coalesce zero-address `target`s to `address(this)`.
     function _execute(Call[] calldata calls, bytes32 keyHash) internal virtual override {

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -188,7 +188,6 @@ contract GuardedExecutor is ERC7821 {
     /// 2. Any token that is granted a non-zero approval will have the approval
     ///    reset to zero after the calls.
     /// 3. The spend limits are only incremented and checked against at the end of a batch.
-    /// 4. We consider 
     /// Note: Called internally in ERC7821, which coalesce zero-address `target`s to `address(this)`.
     function _execute(Call[] calldata calls, bytes32 keyHash) internal virtual override {
         // If self-execute, don't care about the spend permissions.

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -200,6 +200,8 @@ contract GuardedExecutor is ERC7821 {
 
         // Collect all ERC20 tokens that need to be guarded,
         // and initialize their transfer amounts as zero.
+        // Used for the check on their before and after balances, in case the batch calls
+        // some contract that is authorized to transfer out tokens on behalf of the eoa.
         uint256 n = spends.tokens.length();
         for (uint256 i; i < n; ++i) {
             address token = spends.tokens.at(i);

--- a/test/GuardedExecutor.t.sol
+++ b/test/GuardedExecutor.t.sol
@@ -180,15 +180,9 @@ contract GuardedExecutorTest is BaseTest {
         );
     }
 
-    function testSetSpendLimitAndSpendInASingleBatchWithNative() public {
-        _testSetSpendLimitAndSpendInASingleBatch(address(0));
-    }
+    function testSetSpendLimitAndSpendInASingleBatch(bytes32) public {
+        address token = _randomChance(32) ? address(0) : LibClone.clone(address(paymentToken));
 
-    function testSetSpendLimitAndSpendInASingleBatchWithERC20() public {
-        _testSetSpendLimitAndSpendInASingleBatch(LibClone.clone(address(paymentToken)));
-    }
-
-    function _testSetSpendLimitAndSpendInASingleBatch(address token) public {
         EntryPoint.UserOp memory u;
         DelegatedEOA memory d = _randomEIP7702DelegatedEOA();
 

--- a/test/GuardedExecutor.t.sol
+++ b/test/GuardedExecutor.t.sol
@@ -170,6 +170,122 @@ contract GuardedExecutorTest is BaseTest {
         );
     }
 
+    function _removeSpendLimitCall(
+        PassKey memory k,
+        address token,
+        GuardedExecutor.SpendPeriod period
+    ) internal pure returns (ERC7821.Call memory c) {
+        c.data = abi.encodeWithSelector(
+            GuardedExecutor.removeSpendLimit.selector, k.keyHash, token, period
+        );
+    }
+
+    function testSetSpendLimitAndSpendInASingleBatchWithNative() public {
+        _testSetSpendLimitAndSpendInASingleBatch(address(0));
+    }
+
+    function testSetSpendLimitAndSpendInASingleBatchWithERC20() public {
+        _testSetSpendLimitAndSpendInASingleBatch(LibClone.clone(address(paymentToken)));
+    }
+
+    function _testSetSpendLimitAndSpendInASingleBatch(address token) public {
+        EntryPoint.UserOp memory u;
+        DelegatedEOA memory d = _randomEIP7702DelegatedEOA();
+
+        u.eoa = d.eoa;
+        u.combinedGas = 1000000;
+        u.nonce = ep.getNonce(u.eoa, 0);
+
+        PassKey memory k = _randomSecp256k1PassKey();
+        k.k.isSuperAdmin = true;
+
+        _mint(token, u.eoa, type(uint192).max);
+
+        uint256 amount = _bound(_randomUniform(), 0, 0.0001 ether);
+
+        GuardedExecutor.SpendInfo[] memory infos;
+        ERC7821.Call[] memory calls;
+        // Authorize.
+        {
+            calls = new ERC7821.Call[](1);
+            // Authorize the key.
+            calls[0].data = abi.encodeWithSelector(Delegation.authorize.selector, k.k);
+
+            u.executionData = abi.encode(calls);
+            u.nonce = 0xc1d0 << 240;
+
+            u.signature = _eoaSig(d.privateKey, u);
+
+            assertEq(ep.execute(abi.encode(u)), 0);
+        }
+        // Set spend limits and spend in a single batch.
+        {
+            calls = new ERC7821.Call[](2);
+            calls[0] = _setSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour, 1 ether);
+            calls[1] = _transferCall2(token, address(0xb0b), amount);
+
+            u.nonce = ep.getNonce(d.eoa, 0);
+            u.executionData = abi.encode(calls);
+            u.signature = _sig(k, u);
+
+            assertEq(ep.execute(abi.encode(u)), 0);
+
+            infos = d.d.spendInfos(k.keyHash);
+            assertEq(infos.length, 1);
+
+            assertEq(infos[0].token, token);
+            assertEq(infos[0].spent, amount);
+        }
+        // Remove spend limits and spend in a single batch.
+        {
+            calls = new ERC7821.Call[](1);
+            calls[0] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour);
+
+            u.nonce = ep.getNonce(d.eoa, 0);
+            u.executionData = abi.encode(calls);
+            u.signature = _sig(k, u);
+
+            assertEq(ep.execute(abi.encode(u)), 0);
+
+            infos = d.d.spendInfos(k.keyHash);
+            assertEq(infos.length, 0);
+        }
+        // Set spend limits and spend and remove spend limits in a single batch.
+        {
+            calls = new ERC7821.Call[](3);
+            calls[0] = _setSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour, 1 ether);
+            calls[1] = _transferCall2(token, address(0xb0b), amount);
+            calls[2] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour);
+
+            u.nonce = ep.getNonce(d.eoa, 0);
+            u.executionData = abi.encode(calls);
+            u.signature = _sig(k, u);
+
+            assertEq(ep.execute(abi.encode(u)), 0);
+
+            infos = d.d.spendInfos(k.keyHash);
+            assertEq(infos.length, 0);
+        }
+        // Set spend limits and spend in a single batch.
+        {
+            calls = new ERC7821.Call[](2);
+            calls[0] = _setSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour, 1 ether);
+            calls[1] = _transferCall2(token, address(0xb0b), amount);
+
+            u.nonce = ep.getNonce(d.eoa, 0);
+            u.executionData = abi.encode(calls);
+            u.signature = _sig(k, u);
+
+            assertEq(ep.execute(abi.encode(u)), 0);
+
+            infos = d.d.spendInfos(k.keyHash);
+            assertEq(infos.length, 1);
+
+            assertEq(infos[0].token, token);
+            assertEq(infos[0].spent, amount);
+        }
+    }
+
     function testSetAndRemoveSpendLimit() public {
         vm.warp(86400 * 100);
 
@@ -230,12 +346,7 @@ contract GuardedExecutorTest is BaseTest {
         // Test removal reduces infos' length.
         {
             calls = new ERC7821.Call[](1);
-            calls[0].data = abi.encodeWithSelector(
-                GuardedExecutor.removeSpendLimit.selector,
-                k.keyHash,
-                token,
-                GuardedExecutor.SpendPeriod.Hour
-            );
+            calls[0] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour);
 
             u.nonce = ep.getNonce(u.eoa, 0);
             u.executionData = abi.encode(calls);
@@ -294,18 +405,8 @@ contract GuardedExecutorTest is BaseTest {
         // Test removal.
         {
             calls = new ERC7821.Call[](2);
-            calls[0].data = abi.encodeWithSelector(
-                GuardedExecutor.removeSpendLimit.selector,
-                k.keyHash,
-                token,
-                GuardedExecutor.SpendPeriod.Hour
-            );
-            calls[1].data = abi.encodeWithSelector(
-                GuardedExecutor.removeSpendLimit.selector,
-                k.keyHash,
-                token,
-                GuardedExecutor.SpendPeriod.Day
-            );
+            calls[0] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour);
+            calls[1] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Day);
 
             u.nonce = ep.getNonce(u.eoa, 0);
             u.executionData = abi.encode(calls);

--- a/test/GuardedExecutor.t.sol
+++ b/test/GuardedExecutor.t.sol
@@ -236,10 +236,11 @@ contract GuardedExecutorTest is BaseTest {
             assertEq(infos[0].token, token);
             assertEq(infos[0].spent, amount);
         }
-        // Remove spend limits and spend in a single batch.
+        // Remove spend limits and spend above the limit in a single batch.
         {
-            calls = new ERC7821.Call[](1);
-            calls[0] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour);
+            calls = new ERC7821.Call[](2);
+            calls[0] = _transferCall2(token, address(0xb0b), 10 ether);
+            calls[1] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour);
 
             u.nonce = ep.getNonce(d.eoa, 0);
             u.executionData = abi.encode(calls);

--- a/test/GuardedExecutor.t.sol
+++ b/test/GuardedExecutor.t.sol
@@ -217,6 +217,10 @@ contract GuardedExecutorTest is BaseTest {
             calls = new ERC7821.Call[](2);
             calls[0] = _setSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour, 1 ether);
             calls[1] = _transferCall2(token, address(0xb0b), amount);
+            // Check that the order doesn't matter.
+            if (_randomChance(2)) {
+                (calls[0], calls[1]) = (calls[1], calls[0]);
+            }
 
             u.nonce = ep.getNonce(d.eoa, 0);
             u.executionData = abi.encode(calls);
@@ -235,6 +239,10 @@ contract GuardedExecutorTest is BaseTest {
             calls = new ERC7821.Call[](2);
             calls[0] = _transferCall2(token, address(0xb0b), 10 ether);
             calls[1] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour);
+            // Check that the order doesn't matter.
+            if (_randomChance(2)) {
+                (calls[0], calls[1]) = (calls[1], calls[0]);
+            }
 
             u.nonce = ep.getNonce(d.eoa, 0);
             u.executionData = abi.encode(calls);
@@ -251,6 +259,14 @@ contract GuardedExecutorTest is BaseTest {
             calls[0] = _setSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour, 1 ether);
             calls[1] = _transferCall2(token, address(0xb0b), amount);
             calls[2] = _removeSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour);
+            // Check that the order doesn't matter, as long as the remove call is after the set spend call.
+            if (_randomChance(2)) {
+                if (_randomChance(2)) {
+                    (calls[0], calls[1]) = (calls[1], calls[0]);
+                } else {
+                    (calls[1], calls[2]) = (calls[2], calls[1]);
+                }
+            }
 
             u.nonce = ep.getNonce(d.eoa, 0);
             u.executionData = abi.encode(calls);
@@ -266,6 +282,10 @@ contract GuardedExecutorTest is BaseTest {
             calls = new ERC7821.Call[](2);
             calls[0] = _setSpendLimitCall(k, token, GuardedExecutor.SpendPeriod.Hour, 1 ether);
             calls[1] = _transferCall2(token, address(0xb0b), amount);
+            // Check that the order doesn't matter.
+            if (_randomChance(2)) {
+                (calls[0], calls[1]) = (calls[1], calls[0]);
+            }
 
             u.nonce = ep.getNonce(d.eoa, 0);
             u.executionData = abi.encode(calls);


### PR DESCRIPTION
This should be non-breaking, unless you require very specific behavior of GuardedExecutor to only apply the spend limits after a batch.