### PR TITLE
feat: `AccountRegistry`

### DIFF
--- a/src/AccountRegistry.sol
+++ b/src/AccountRegistry.sol
@@ -91,4 +91,14 @@ contract AccountRegistry {
 
         accounts.accounts.add(account);
     }
+
+    /// @dev Removes the account from the ID. This is useful when a user wants to disassociate a key from an account.
+    /// Must be invoked by the account itself.
+    function removeAccount(address id) external {
+        StoredAccounts storage accounts = _getAccountRegistryStorage().accounts[id];
+
+        if (!accounts.accounts.contains(msg.sender)) revert InvalidCaller();
+
+        accounts.accounts.remove(msg.sender);
+    }
 }

--- a/src/AccountRegistry.sol
+++ b/src/AccountRegistry.sol
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {ECDSA} from "solady/utils/ECDSA.sol";
+import {EnumerableSetLib} from "solady/utils/EnumerableSetLib.sol";
+
+/// @title AccountRegistry
+/// @dev This is a simple on-chain storage for user accounts in a form of mapping
+/// ID -> (Data, Address[]). To avoid front-running, the ID is not an arbitrary value, but
+/// an address that needs to sign the payload mapping is initialized with.
+///
+/// Once the ID is occupied, the only way it can be modified is by appending a new account.
+/// The only way to append an account is by invoking `appendAccount` method from an already
+/// registered account.
+contract AccountRegistry {
+    using EnumerableSetLib for EnumerableSetLib.AddressSet;
+
+    /// @dev The ID has already been registered.
+    error IDOccupied();
+
+    /// @dev Caller is not authorized to modify the ID.
+    error InvalidCaller();
+
+    /// @dev Account is already registered in the ID.
+    error AlreadyRegistered();
+
+    /// @dev Contents of an ID. Each ID is associated with an arbitrary
+    /// user-defined data blob and a list of accounts.
+    struct StoredAccounts {
+        /// @dev Arbitrary data associated with the ID.
+        bytes data;
+        /// @dev Accounts associated with the ID.
+        EnumerableSetLib.AddressSet accounts;
+    }
+
+    /// @dev The storage of the contract.
+    struct AccountRegistryStorage {
+        /// @dev Mapping of ID to the stored accounts.
+        mapping(address id => StoredAccounts) accounts;
+    }
+
+    /// @dev Returns the storage pointer.
+    function _getAccountRegistryStorage()
+        internal
+        pure
+        returns (AccountRegistryStorage storage $)
+    {
+        // Truncate to 9 bytes to reduce bytecode size.
+        uint256 s = uint72(bytes9(keccak256("PORTO_ACCOUNT_REGISTRY_STORAGE")));
+        assembly ("memory-safe") {
+            $.slot := s
+        }
+    }
+
+    /// @dev Returns the state of a given ID, including the data and accounts.
+    /// @param id ID to lookup.
+    function idInfo(address id)
+        public
+        view
+        returns (bytes memory data, address[] memory accounts)
+    {
+        StoredAccounts storage storedAccounts = _getAccountRegistryStorage().accounts[id];
+        data = storedAccounts.data;
+        accounts = storedAccounts.accounts.values();
+    }
+
+    /// @dev Registers a new ID with the given `data` and `account`.
+    /// @param signature Signature over `keccak256(abi.encode(data, account))`. The recovered signer
+    /// is the ID.
+    /// @param data Arbitrary data blob to associate with the ID.
+    /// @param account First account to associate with the ID.
+    function register(bytes calldata signature, bytes calldata data, address account) external {
+        address id = ECDSA.recoverCalldata(keccak256(abi.encode(data, account)), signature);
+        StoredAccounts storage accounts = _getAccountRegistryStorage().accounts[id];
+
+        if (accounts.accounts.length() > 0) revert IDOccupied();
+
+        accounts.data = data;
+        accounts.accounts.add(account);
+    }
+
+    /// @dev Appends a new account to the ID. This is useful when a user wants to associate a key with multiple accounts.
+    /// We require the caller of this method to be an already registered account.
+    /// @param id Inititalized ID to append the account to.
+    /// @param account Account to append to the ID.
+    function appendAccount(address id, address account) external {
+        StoredAccounts storage accounts = _getAccountRegistryStorage().accounts[id];
+
+        if (!accounts.accounts.contains(msg.sender)) revert InvalidCaller();
+        if (accounts.accounts.contains(account)) revert AlreadyRegistered();
+
+        accounts.accounts.add(account);
+    }
+}

--- a/src/AccountRegistry.sol
+++ b/src/AccountRegistry.sol
@@ -95,10 +95,13 @@ contract AccountRegistry {
     /// @dev Removes the account from the ID. This is useful when a user wants to disassociate a key from an account.
     /// Must be invoked by the account itself.
     function removeAccount(address id) external {
-        StoredAccounts storage accounts = _getAccountRegistryStorage().accounts[id];
+        AccountRegistryStorage storage $ = _getAccountRegistryStorage();
 
-        if (!accounts.accounts.contains(msg.sender)) revert InvalidCaller();
+        if (!$.accounts[id].accounts.contains(msg.sender)) revert InvalidCaller();
+        $.accounts[id].accounts.remove(msg.sender);
 
-        accounts.accounts.remove(msg.sender);
+        if ($.accounts[id].accounts.length() == 0) {
+            delete $.accounts[id];
+        }
     }
 }

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+import {AccountRegistry} from "./AccountRegistry.sol";
 import {LibBitmap} from "solady/utils/LibBitmap.sol";
 import {LibERC7579} from "solady/accounts/LibERC7579.sol";
 import {Ownable} from "solady/auth/Ownable.sol";
@@ -35,7 +36,13 @@ import {LibNonce} from "./LibNonce.sol";
 /// - Minimize chance of censorship.
 ///   This means once an UserOp is signed, it is infeasible to
 ///   alter or rearrange it to force it to fail.
-contract EntryPoint is EIP712, Ownable, CallContextChecker, ReentrancyGuardTransient {
+contract EntryPoint is
+    AccountRegistry,
+    EIP712,
+    Ownable,
+    CallContextChecker,
+    ReentrancyGuardTransient
+{
     using LibERC7579 for bytes32[];
     using EfficientHashLib for bytes32[];
     using LibBitmap for LibBitmap.Bitmap;


### PR DESCRIPTION
Adds `AccountRegistry` with 3 methods:
- `register` - to initialize a mapping for the given ID with an account and arbitrary data blob.
- `appendAccount` - to add a new account to the ID.
- `idInfo` to fetch the data blob and a list of accounts.