### PR TITLE
feat: add `getKeys()` to `Delegation` contract

### DIFF
--- a/hello
+++ b/hello
@@ -1,1 +1,0 @@
-Compiling 62 files with Solc 0.8.28

--- a/test/Delegation.t.sol
+++ b/test/Delegation.t.sol
@@ -287,8 +287,8 @@ contract DelegationTest is BaseTest {
         Delegation.Key memory k;
         k.keyType = Delegation.KeyType(_randomUniform() & 1);
 
-        for(uint i=0; i < 20; i++){
-            k.expiry = uint40(i);
+        for (uint40 i = 0; i < 20; i++) {
+            k.expiry = i;
             k.publicKey = abi.encode(i);
             vm.prank(d.eoa);
             d.d.authorize(k);


### PR DESCRIPTION
To be used only on `eth_call` to fetch all keys from an account.

500 keys: 1.5M gas
700 keys: 2.1M gas