### PR TITLE
feat: verify contracts in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -22,5 +22,7 @@ jobs:
         run: | 
           forge script DeployAllScript \
             --rpc-url "https://odyssey.ithaca.xyz" \
-            --broadcast -q && \
+            --broadcast -q --verify --verifier blockscout \
+            --verifier-url "https://odyssey-explorer.ithaca.xyz/api" \
+            --evm-version cancun && \ # TODO: remove once https://github.com/blockscout/blockscout/pull/12115 is released.
           jq -r '.transactions[].additionalContracts | "EntryPoint: " + .[0].address, "Delegation: "  + .[1].address, "EIP7702Proxy: " + .[2].address'  broadcast/DeployAll.s.sol/911867/run-latest.json


### PR DESCRIPTION
Blockscout does not accept `prague` EVM version by default. This should be fixed with https://github.com/blockscout/blockscout/pull/12115. For now this PR sets the `evm_version` to `cancun` as `prague` is basically the same thing from solc pov

Closes https://github.com/ithacaxyz/account/issues/84