### PR TITLE
fix: use nightly foundry for deploy

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -16,6 +16,8 @@ jobs:
           submodules: 'recursive'
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
       - name: Deploy
         env:
           PRIVATE_KEY: ${{ secrets.deployer }}


### PR DESCRIPTION
We need https://github.com/foundry-rs/foundry/pull/9979 which is not available in `stable` foundry for now, hence verification is silently failing