### PR TITLE
chore: change variable names to silence compiler warning

### DIFF
--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -484,15 +484,15 @@ abstract contract GuardedExecutor is ERC7821 {
         public
         view
         virtual
-        returns (SpendInfo[][] memory spend, bytes32[][] memory canExecute)
+        returns (SpendInfo[][] memory spends, bytes32[][] memory executes)
     {
         uint256 count = keyHashes.length;
-        spend = new SpendInfo[][](count);
-        canExecute = new bytes32[][](count);
+        spends = new SpendInfo[][](count);
+        executes = new bytes32[][](count);
 
         for (uint256 i = 0; i < count; i++) {
-            spend[i] = spendInfos(keyHashes[i]);
-            canExecute[i] = canExecutePackedInfos(keyHashes[i]);
+            spends[i] = spendInfos(keyHashes[i]);
+            executes[i] = canExecutePackedInfos(keyHashes[i]);
         }
     }
 


### PR DESCRIPTION
Silence compiler warnings

```bash
Compiler run successful with warnings:
Warning (2519): This declaration shadows an existing declaration.
   --> src/GuardedExecutor.sol:487:46:
    |
487 |         returns (SpendInfo[][] memory spend, bytes32[][] memory canExecute)
    |                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Note: The shadowed declaration is here:
   --> src/GuardedExecutor.sol:395:5:
    |
395 |     function canExecute(bytes32 keyHash, address target, bytes calldata data)
    |     ^ (Relevant source part starts here and spans across multiple lines).

```