### PR TITLE
fix: compensate spend limits

### DIFF
--- a/.changeset/new-shirts-film.md
+++ b/.changeset/new-shirts-film.md
@@ -1,0 +1,5 @@
+---
+"porto-account": patch
+---
+
+Add compensate spend limits. Note that the `compensate` function is refactored to have a `keyHash` parameter.

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -493,6 +493,7 @@ contract Delegation is EIP712, GuardedExecutor {
         address paymentRecipient,
         uint256 paymentAmount,
         address eoa,
+        bytes32 keyHash,
         bytes32 userOpDigest,
         bytes calldata paymentSignature
     ) public virtual {

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -499,6 +499,11 @@ contract Delegation is EIP712, GuardedExecutor {
     ) public virtual {
         if (!LibBit.and(msg.sender == ENTRY_POINT, eoa == address(this))) revert Unauthorized();
         TokenTransferLib.safeTransfer(paymentToken, paymentRecipient, paymentAmount);
+        // Increase spend.
+        if (!(keyHash == bytes32(0) || _isSuperAdmin(keyHash))) {
+            SpendStorage storage spends = _getGuardedExecutorKeyStorage(keyHash).spends;
+            _incrementSpent(spends.spends[paymentToken], paymentAmount);
+        }
         // Silence unused variables warning.
         userOpDigest = userOpDigest;
         paymentSignature = paymentSignature;

--- a/test/utils/mocks/MockPayerWithSignature.sol
+++ b/test/utils/mocks/MockPayerWithSignature.sol
@@ -19,6 +19,7 @@ contract MockPayerWithSignature is Ownable {
         address paymentRecipient,
         uint256 paymentAmount,
         address eoa,
+        bytes32 keyHash,
         bytes32 userOpDigest,
         bytes paymentSignature
     );
@@ -50,6 +51,7 @@ contract MockPayerWithSignature is Ownable {
         address paymentRecipient,
         uint256 paymentAmount,
         address eoa,
+        bytes32 keyHash,
         bytes32 userOpDigest,
         bytes calldata paymentSignature
     ) public virtual {
@@ -60,9 +62,15 @@ contract MockPayerWithSignature is Ownable {
             revert InvalidSignature();
         }
         // Emit the event for debugging.
-        // The `eoa` is not used.
+        // The `eoa` and `keyHash` are not used.
         emit Compensated(
-            paymentToken, paymentRecipient, paymentAmount, eoa, userOpDigest, paymentSignature
+            paymentToken,
+            paymentRecipient,
+            paymentAmount,
+            eoa,
+            keyHash,
+            userOpDigest,
+            paymentSignature
         );
     }
 

--- a/test/utils/mocks/MockPayerWithState.sol
+++ b/test/utils/mocks/MockPayerWithState.sol
@@ -19,6 +19,7 @@ contract MockPayerWithState is Ownable {
         address paymentRecipient,
         uint256 paymentAmount,
         address eoa,
+        bytes32 keyHash,
         bytes32 userOpDigest,
         bytes paymentSignature
     );
@@ -52,6 +53,7 @@ contract MockPayerWithState is Ownable {
         address paymentRecipient,
         uint256 paymentAmount,
         address eoa,
+        bytes32 keyHash,
         bytes32 userOpDigest,
         bytes calldata paymentSignature
     ) public virtual {
@@ -60,9 +62,15 @@ contract MockPayerWithState is Ownable {
         funds[paymentToken][eoa] -= paymentAmount;
         TokenTransferLib.safeTransfer(paymentToken, paymentRecipient, paymentAmount);
         // Emit the event for debugging.
-        // The `userOpDigest` and `paymentSignature` are not used.
+        // The `keyHash`, `userOpDigest` and `paymentSignature` are not used.
         emit Compensated(
-            paymentToken, paymentRecipient, paymentAmount, eoa, userOpDigest, paymentSignature
+            paymentToken,
+            paymentRecipient,
+            paymentAmount,
+            eoa,
+            keyHash,
+            userOpDigest,
+            paymentSignature
         );
     }
 


### PR DESCRIPTION
Continued from 105.

- The `compensate` function has been refactored to take in an additional `keyHash` parameter.