### PR TITLE
fix: make simulateExecute directly revert on PaymentError

### DIFF
--- a/.changeset/tangy-suns-study.md
+++ b/.changeset/tangy-suns-study.md
@@ -1,0 +1,5 @@
+---
+"porto-account": patch
+---
+
+Fix simulateExecute missing revert if PaymentError"

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -389,7 +389,9 @@ contract EntryPoint is
         if (msg.sender.balance != type(uint256).max) {
             revert SimulationResult(gExecute, gCombined, gUsed, err);
         }
-        // If `err` is `PaymentError()`, we don't need to do the final simulation.
+        // If `err` is `PaymentError()`, directly revert, as `gCombined` will be zero,
+        // and `paymentOverride` will thus be zero, which won't trigger the revert
+        // in the final simulation.
         if (err == PaymentError.selector) revert PaymentError();
         // Every time I use `abi.decode` and `abi.encode` a part of me dies.
         UserOp memory u = abi.decode(encodedUserOp, (UserOp));

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -392,6 +392,9 @@ contract EntryPoint is
         // Every time I use `abi.decode` and `abi.encode` a part of me dies.
         UserOp memory u = abi.decode(encodedUserOp, (UserOp));
         uint256 paymentOverride = Math.saturatingMul(gCombined, u.paymentPerGas);
+        if (LibBit.and(paymentOverride == uint256(0), err == PaymentError.selector)) {
+            paymentOverride = type(uint256).max;
+        }
         u.paymentAmount = paymentOverride;
         u.paymentMaxAmount = paymentOverride;
         (bool success, bytes memory result) = address(this).call(

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -391,7 +391,7 @@ contract EntryPoint is
         }
         // If `err` is `PaymentError()`, directly revert, as `gCombined` will be zero,
         // and `paymentOverride` will thus be zero, which won't trigger the revert
-        // in the final simulation.
+        // in the final simulation. And we need the simulation to revert.
         if (err == PaymentError.selector) revert PaymentError();
         // Every time I use `abi.decode` and `abi.encode` a part of me dies.
         UserOp memory u = abi.decode(encodedUserOp, (UserOp));

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -389,12 +389,11 @@ contract EntryPoint is
         if (msg.sender.balance != type(uint256).max) {
             revert SimulationResult(gExecute, gCombined, gUsed, err);
         }
+        // If `err` is `PaymentError()`, we don't need to do the final simulation.
+        if (err == PaymentError.selector) revert PaymentError();
         // Every time I use `abi.decode` and `abi.encode` a part of me dies.
         UserOp memory u = abi.decode(encodedUserOp, (UserOp));
         uint256 paymentOverride = Math.saturatingMul(gCombined, u.paymentPerGas);
-        if (LibBit.and(paymentOverride == uint256(0), err == PaymentError.selector)) {
-            paymentOverride = type(uint256).max;
-        }
         u.paymentAmount = paymentOverride;
         u.paymentMaxAmount = paymentOverride;
         (bool success, bytes memory result) = address(this).call(

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -407,7 +407,7 @@ contract EntryPoint is
             )
         );
         if (!success) {
-            assembly {
+            assembly ("memory-safe") {
                 revert(add(0x20, result), mload(result))
             }
         }


### PR DESCRIPTION
So, when `err == PaymentError.selector`, `gCombined` will be left as default 0 -> `paymentOverride = 0` -> final simulation won't revert. 

So the fix is to directly revert if `err == PaymentError.selector`, for the no-revert `simulateExecute` workflow.