### PR TITLE
Automating gas benchmark diffs with main in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,3 +34,9 @@ jobs:
       - name: Run tests (odyssey)
         run: |
           forge test -vvv --odyssey
+
+      - name: Snapshot main branch
+        run: git fetch origin main && git worktree prune &&rm -rf .snapshot_worktree && git worktree add .snapshot_worktree origin/main && (cd .snapshot_worktree && forge snapshot --match-contract Benchmark --snap .temp-snapshot) && cp .snapshot_worktree/.temp-snapshot gas-snapshots/.gas-snapshot-main && git worktree remove --force .snapshot_worktree && git worktree prune
+
+      - name: Compare gas snapshots
+        run: forge snapshot --match-contract Benchmark --diff gas-snapshots/.gas-snapshot-main

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.0.3",
   "description": "EIP-7702 account for Ithaca Porto",
   "license": "MIT",
+  "scripts": {
+    "snapshot:main": "git fetch origin main && git worktree prune &&rm -rf .snapshot_worktree && git worktree add .snapshot_worktree origin/main && (cd .snapshot_worktree && forge snapshot --match-contract Benchmark --snap .temp-snapshot) && cp .snapshot_worktree/.temp-snapshot gas-snapshots/.gas-snapshot-main && git worktree remove --force .snapshot_worktree && git worktree prune"
+  },
   "devDependencies": {
     "@changesets/cli": "^2.28.1"
   }


### PR DESCRIPTION
Fetches the latest gas snapshot from main branch, and diffs them against the current PR.

Helps to make sure that new PRs don't regress on old benchmarks.

Right now, the diffs are only visible in the CI run. We could consider posting them as a comment on the PR itself, but this requires adding a github token in the secrets.

Thoughts?