### PR TITLE
chore: update payment in combinedGas loop

### DIFF
--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -176,6 +176,8 @@ contract Simulator {
                 return (gasUsed, u.combinedGas);
             }
 
+            _updatePaymentAmounts(u, isPrePayment, gasUsed, paymentPerGas);
+
             // Step up the combined gas, until we see a simulation passing
             u.combinedGas += Math.mulDiv(u.combinedGas, combinedGasIncrement, 10_000);
         }


### PR DESCRIPTION
We do this to cover edge cases in paymaster flows, where a small change in the payment amount can cause big codepath changes, causing simulation to fail.