### PR TITLE
feat: Allow Porto Delegation accounts to act as Paymasters

### DIFF
--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -7,7 +7,7 @@ import "../src/DeployAll.sol";
 contract DeployAllScript is Script {
     function run() external {
         uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        address deployer = vm.createWallet(deployerPrivateKey).addr;
+        vm.createWallet(deployerPrivateKey).addr;
         vm.startBroadcast(deployerPrivateKey);
         new DeployAll();
         vm.stopBroadcast();

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -548,7 +548,7 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
 
             if (!isValid) {
                 // The error is skipped, if the paymaster is in simulation mode.
-                /// @dev to simulate a paymaster, state override the address of the delegation
+                /// @dev to simulate a paymaster, state override the address of the entrypoint
                 /// to type(uint256).max
                 revert Unauthorized();
             }

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -70,8 +70,6 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
 
     /// @dev Holds the storage.
     struct DelegationStorage {
-        /// @dev 32 byte word for bit flags, can be extended to add features in future upgrades.
-        uint256 flags;
         /// @dev The label.
         LibBytes.BytesStorage label;
         /// @dev The `r` value for the secp256k1 curve to show that this contract is a PREP.
@@ -206,9 +204,6 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
     /// @dev General capacity for enumerable sets,
     /// to prevent off-chain full enumeration from running out-of-gas.
     uint256 internal constant _CAP = 512;
-
-    /// @dev Bit position of simulation flag.
-    uint256 internal constant SIMULATION_FLAG = 0;
 
     ////////////////////////////////////////////////////////////////////////
     // Constructor
@@ -544,13 +539,17 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
 
         // If this delegation is the paymaster, and the simulation flag is not set, validate the paymaster signature.
         if (userOp.payer == address(this)) {
-            (bool isValid, bytes32 paymasterKeyHash) =
-                unwrapAndValidateSignature(userOpDigest, userOp.paymentSignature);
+            (bool isValid,) = unwrapAndValidateSignature(userOpDigest, userOp.paymentSignature);
 
-            if (
-                _getDelegationStorage().flags & (1 << SIMULATION_FLAG) != 0
-                    && !LibBit.and(isValid, _isSuperAdmin(paymasterKeyHash))
-            ) {
+            // If this is a simulation, signature validation errors are skipped.
+            if (address(ENTRY_POINT).balance == type(uint256).max) {
+                isValid = true;
+            }
+
+            if (!isValid) {
+                // The error is skipped, if the paymaster is in simulation mode.
+                /// @dev to simulate a paymaster, state override the address of the delegation
+                /// to type(uint256).max
                 revert Unauthorized();
             }
         }

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -537,19 +537,18 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
             revert Unauthorized();
         }
 
-        // If this delegation is the paymaster, and the simulation flag is not set, validate the paymaster signature.
+        // If this delegation is the paymaster, validate the paymaster signature.
         if (userOp.payer == address(this)) {
             (bool isValid,) = unwrapAndValidateSignature(userOpDigest, userOp.paymentSignature);
 
             // If this is a simulation, signature validation errors are skipped.
+            /// @dev to simulate a paymaster, state override the balance of the msg.sender
+            /// to type(uint256).max. In this case, the msg.sender is the ENTRY_POINT.
             if (address(ENTRY_POINT).balance == type(uint256).max) {
                 isValid = true;
             }
 
             if (!isValid) {
-                // The error is skipped, if the paymaster is in simulation mode.
-                /// @dev to simulate a paymaster, state override the address of the entrypoint
-                /// to type(uint256).max
                 revert Unauthorized();
             }
         }

--- a/src/EntryPoint.sol
+++ b/src/EntryPoint.sol
@@ -642,7 +642,7 @@ contract EntryPoint is IEntryPoint, EIP712, CallContextChecker, ReentrancyGuardT
 
         // Call the pay function on the delegation contract
         // Equivalent Solidity code:
-        // IDelegation(payer).pay(paymentAmount, keyHash, abi.encode(u));
+        // IDelegation(payer).pay(paymentAmount, keyHash, digest, abi.encode(u));
         // Gas Savings:
         // Saves ~2k gas for normal use cases, by avoiding abi.encode and solidity external call overhead
         assembly ("memory-safe") {

--- a/test/EntryPoint.t.sol
+++ b/test/EntryPoint.t.sol
@@ -737,8 +737,6 @@ contract EntryPointTest is BaseTest {
         u.eoa = d.eoa;
         u.payer = address(payer.d);
 
-        console.log("u.payer", u.payer);
-        console.log("u.eoa", u.eoa);
         u.nonce = d.d.getNonce(0);
         u.paymentToken = isNative ? address(0) : address(paymentToken);
         u.prePaymentAmount = _bound(_random(), 0, 1 ether);
@@ -754,8 +752,8 @@ contract EntryPointTest is BaseTest {
 
         bytes32 digest = ep.computeDigest(u);
 
-        // vm.expectRevert(bytes4(keccak256("Unauthorized()")));
-        // _simulateExecute(u, false, 1, 11_000, 0);
+        vm.expectRevert(bytes4(keccak256("Unauthorized()")));
+        _simulateExecute(u, false, 1, 11_000, 0);
 
         uint256 snapshot = vm.snapshotState();
         // To allow paymasters to be used in simulation mode.

--- a/test/EntryPoint.t.sol
+++ b/test/EntryPoint.t.sol
@@ -169,7 +169,6 @@ contract EntryPointTest is BaseTest {
         u.eoa = d.eoa;
         u.nonce = 0;
         u.executionData = _transferExecutionData(address(paymentToken), address(0xabcd), 1 ether);
-        u.payer = d.eoa;
         u.paymentToken = address(paymentToken);
         u.paymentRecipient = address(this);
         u.prePaymentAmount = 10 ether;
@@ -202,7 +201,7 @@ contract EntryPointTest is BaseTest {
             u.nonce = 0;
             u.executionData =
                 _transferExecutionData(address(paymentToken), address(0xabcd), 0.5 ether);
-            u.payer = ds[i].eoa;
+
             u.paymentToken = address(paymentToken);
             u.paymentRecipient = address(0xbcde);
             u.prePaymentAmount = 0.5 ether;
@@ -238,7 +237,6 @@ contract EntryPointTest is BaseTest {
         u.eoa = d.eoa;
         u.nonce = 0;
         u.executionData = abi.encode(calls);
-        u.payer = d.eoa;
         u.paymentToken = address(paymentToken);
         u.paymentRecipient = address(0xbcde);
         u.prePaymentAmount = 10 ether;
@@ -717,6 +715,68 @@ contract EntryPointTest is BaseTest {
             assertEq(t.retrievedSessionNonce, pSession.nonce | 1);
             assertEq(t.retrievedSuperAdminNonce, pSuperAdmin.nonce | 1);
         }
+    }
+
+    function testDelegationPaymaster(bytes32) public {
+        DelegatedEOA memory d = _randomEIP7702DelegatedEOA();
+        DelegatedEOA memory payer = _randomEIP7702DelegatedEOA();
+
+        bool isNative = _randomChance(2);
+
+        if (isNative) {
+            vm.deal(address(payer.d), type(uint192).max);
+        } else {
+            _mint(address(paymentToken), address(payer.d), type(uint192).max);
+        }
+
+        // 1 ether in the EOA for execution.
+        vm.deal(address(d.d), 1 ether);
+
+        EntryPoint.UserOp memory u;
+
+        u.eoa = d.eoa;
+        u.payer = address(payer.d);
+
+        console.log("u.payer", u.payer);
+        console.log("u.eoa", u.eoa);
+        u.nonce = d.d.getNonce(0);
+        u.paymentToken = isNative ? address(0) : address(paymentToken);
+        u.prePaymentAmount = _bound(_random(), 0, 1 ether);
+        u.prePaymentMaxAmount = _bound(_random(), u.prePaymentAmount, 2 ether);
+        u.totalPaymentAmount = _bound(_random(), u.prePaymentAmount, 5 ether);
+        u.totalPaymentMaxAmount = _bound(_random(), u.totalPaymentAmount, 10 ether);
+
+        if (u.prePaymentMaxAmount > u.totalPaymentMaxAmount) {
+            u.totalPaymentMaxAmount = u.prePaymentMaxAmount;
+        }
+        u.executionData = _transferExecutionData(address(0), address(0xabcd), 1 ether);
+        u.paymentRecipient = address(0x12345);
+
+        bytes32 digest = ep.computeDigest(u);
+
+        // vm.expectRevert(bytes4(keccak256("Unauthorized()")));
+        // _simulateExecute(u, false, 1, 11_000, 0);
+
+        uint256 snapshot = vm.snapshotState();
+        // To allow paymasters to be used in simulation mode.
+        vm.deal(address(ep), type(uint256).max);
+        (uint256 gExecute, uint256 gCombined,) = _estimateGas(u);
+        vm.revertToStateAndDelete(snapshot);
+        u.combinedGas = gCombined;
+
+        digest = ep.computeDigest(u);
+        u.signature = _eoaSig(d.privateKey, digest);
+        u.paymentSignature = _eoaSig(payer.privateKey, digest);
+
+        uint256 payerBalanceBefore = _balanceOf(u.paymentToken, address(payer.d));
+        assertEq(ep.execute{gas: gExecute}(abi.encode(u)), 0);
+        assertEq(d.d.getNonce(0), u.nonce + 1);
+        assertEq(_balanceOf(u.paymentToken, u.paymentRecipient), u.totalPaymentAmount);
+        assertEq(
+            _balanceOf(u.paymentToken, address(payer.d)), payerBalanceBefore - u.totalPaymentAmount
+        );
+        assertEq(address(d.d).balance, 0);
+        assertEq(address(0xabcd).balance, 1 ether);
     }
 
     struct _TestPayViaAnotherPayerTemps {


### PR DESCRIPTION
Allows delegation to be the paymaster.

@relay Note that after this PR, if you explicitly set the payer field to the EOA itself for normal flows, then it will give an error, because it will consider the EOA to be a paymaster.

For non-paymaster flows, u.payer should just be left empty.