### PR TITLE
Add External key type + multi sig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # porto-account
+## 0.1.3
+
+### Patch Changes
+
+- Adds support for `External` keytype. Which allows external contracts that implement the `ISigner` 
+  to verify signatures.
+- Adds a `MultiSigSigner` which adds multi-sig support to the account, using `External` keytype.
+- Adds a stack of `context key hashes` to the account. External observers can check which key signed
+  the account's current execution, by calling the `getContextKeyHash` function on the msg.sender.
+  This has a variety of usecases like validating key operations, setting data in account registry etc.
+- Only adds features. Should not have breaking changes for the relay.
 
 ## 0.1.4
 

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -402,6 +402,8 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
         }
     }
 
+    /// @dev Return the key hash that signed the latest execution context.
+    /// @dev Returns bytes32(0) if the EOA key was used.
     function getContextKeyHash() public view virtual returns (bytes32) {
         LibTStack.TStack memory t = LibTStack.tStack(_KEYHASH_STACK_TRANSIENT_SLOT);
         if (LibTStack.size(t) == 0) {

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -403,7 +403,12 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
     }
 
     function getContextKeyHash() public view virtual returns (bytes32) {
-        return LibTStack.TStack(_KEYHASH_STACK_TRANSIENT_SLOT).top();
+        LibTStack.TStack memory t = LibTStack.tStack(_KEYHASH_STACK_TRANSIENT_SLOT);
+        if (LibTStack.size(t) == 0) {
+            return bytes32(0);
+        }
+
+        return LibTStack.top(t);
     }
 
     /// @dev Returns the hash of the key, which does not includes the expiry.

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -43,7 +43,8 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
     enum KeyType {
         P256,
         WebAuthnP256,
-        Secp256k1
+        Secp256k1,
+        MultiSig
     }
 
     /// @dev A key that can be used to authorize call.
@@ -69,6 +70,8 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
         /// @dev The `msg.senders` that can use `isValidSignature`
         /// to successfully validate a signature for a given key hash.
         EnumerableSetLib.AddressSet checkers;
+        /// @dev Arbitrary data for any key type.
+        bytes data;
     }
 
     /// @dev Holds the storage.
@@ -582,6 +585,7 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
             keyHash = LibBytes.loadCalldata(signature, n);
             signature = LibBytes.truncatedCalldata(signature, n);
             // Do the prehash if last byte is non-zero.
+            // TODO: When do we use this?
             if (uint256(LibBytes.loadCalldata(signature, n + 1)) & 0xff != 0) {
                 digest = EfficientHashLib.sha2(digest); // `sha256(abi.encode(digest))`.
             }
@@ -591,7 +595,45 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
         // Early return if the key has expired.
         if (LibBit.and(key.expiry != 0, block.timestamp > key.expiry)) return (false, keyHash);
 
-        if (key.keyType == KeyType.P256) {
+        if (key.keyType == KeyType.MultiSig) {
+            bytes memory keyData = _getKeyExtraStorage(keyHash).data;
+            bytes[] memory signatures = abi.decode(signature, (bytes[]));
+            (uint256 threshold, bytes32[] memory multiSigKeys) =
+                abi.decode(keyData, (uint256, bytes32[]));
+
+            uint256 validKeyNum;
+
+            for (uint256 i; i < signatures.length; ++i) {
+                // temporary self call to make this work with a memory array
+                (bool v, bytes32 k) = this.unwrapAndValidateSignature(digest, signatures[i]);
+
+                if (!v) {
+                    return (false, keyHash);
+                }
+
+                uint256 j;
+                while (j < multiSigKeys.length) {
+                    if (multiSigKeys[j] == k) {
+                        validKeyNum++;
+                        multiSigKeys[j] = bytes32(0);
+                    }
+
+                    if (validKeyNum == threshold) {
+                        return (true, keyHash);
+                    }
+
+                    j++;
+                }
+
+                // This means that the keyHash was not found
+                if (j == multiSigKeys.length) {
+                    return (false, keyHash);
+                }
+            }
+
+            // If we reach here, then the required threshold was not met.
+            return (false, keyHash);
+        } else if (key.keyType == KeyType.P256) {
             // The try decode functions returns `(0,0)` if the bytes is too short,
             // which will make the signature check fail.
             (bytes32 r, bytes32 s) = P256.tryDecodePointCalldata(signature);

--- a/src/Delegation.sol
+++ b/src/Delegation.sol
@@ -625,7 +625,6 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
 
             address signer = address(bytes20(key.publicKey));
 
-            // MagicValue: bytes4(keccak256("isValidSignature(bytes32,bytes)")
             assembly ("memory-safe") {
                 let m := mload(0x40)
                 mstore(m, 0x8afc93b4) // `isValidSignatureWithKeyHash(bytes32,bytes32,bytes)`
@@ -638,6 +637,7 @@ contract Delegation is IDelegation, EIP712, GuardedExecutor {
                 let size := add(signature.length, 0x84)
                 let success := staticcall(gas(), signer, add(m, 0x1c), size, 0x00, 0x20)
 
+                // MagicValue: bytes4(keccak256("isValidSignatureWithKeyHash(bytes32,bytes32,bytes)")
                 if and(success, eq(shr(224, mload(0x00)), 0x8afc93b4)) { isValid := true }
             }
         }

--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -29,6 +29,9 @@ contract MultiSigSigner is ISigner {
     /// @dev The key hash is invalid.
     error InvalidKeyHash();
 
+    /// @dev Multisigs cannot be re-initialized.
+    error ConfigAlreadySet();
+
     ////////////////////////////////////////////////////////////////////////
     // Storage
     ////////////////////////////////////////////////////////////////////////
@@ -54,10 +57,14 @@ contract MultiSigSigner is ISigner {
     function setConfig(bytes32 keyHash, uint256 threshold, bytes32[] memory ownerKeyHashes)
         public
     {
-        _checkKeyHash(keyHash);
-
         // Threshold can't be zero
         if (threshold == 0) revert InvalidThreshold();
+
+        Config storage config = configs[msg.sender][keyHash];
+
+        if (config.ownerKeyHashes.length > 0) {
+            revert ConfigAlreadySet();
+        }
 
         configs[msg.sender][keyHash] =
             Config({threshold: threshold, ownerKeyHashes: ownerKeyHashes});

--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -11,10 +11,10 @@ contract MultiSigSigner is ISigner {
 
     /// @dev The magic value returned by `isValidSignatureWithKeyHash` when the signature is valid.
     /// - Calcualated as: bytes4(keccak256("isValidSignatureWithKeyHash(bytes32,bytes32,bytes)")
-    bytes4 internal constant MAGIC_VALUE = 0x8afc93b4;
+    bytes4 internal constant _MAGIC_VALUE = 0x8afc93b4;
 
     /// @dev The magic value returned by `isValidSignatureWithKeyHash` when the signature is invalid.
-    bytes4 internal constant FAIL_VALUE = 0xffffffff;
+    bytes4 internal constant _FAIL_VALUE = 0xffffffff;
 
     ////////////////////////////////////////////////////////////////////////
     // Errors
@@ -63,7 +63,7 @@ contract MultiSigSigner is ISigner {
         if (keyHash != expectedKeyHash) revert InvalidKeyHash();
     }
 
-    function setConfig(bytes32 keyHash, uint256 threshold, bytes32[] memory ownerKeyHashes)
+    function initConfig(bytes32 keyHash, uint256 threshold, bytes32[] memory ownerKeyHashes)
         public
     {
         // Threshold can't be zero
@@ -156,7 +156,7 @@ contract MultiSigSigner is ISigner {
                     config.ownerKeyHashes[j] = bytes32(0);
 
                     if (validKeyNum == config.threshold) {
-                        return MAGIC_VALUE;
+                        return _MAGIC_VALUE;
                     }
 
                     break;
@@ -169,11 +169,11 @@ contract MultiSigSigner is ISigner {
 
             // This means that the keyHash was not found
             if (j == config.ownerKeyHashes.length) {
-                return FAIL_VALUE;
+                return _FAIL_VALUE;
             }
         }
 
         // If we reach here, then the required threshold was not met.
-        return FAIL_VALUE;
+        return _FAIL_VALUE;
     }
 }

--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -62,7 +62,7 @@ contract MultiSigSigner is ISigner {
 
         Config storage config = configs[msg.sender][keyHash];
 
-        if (config.ownerKeyHashes.length > 0) {
+        if (config.threshold > 0) {
             revert ConfigAlreadySet();
         }
 
@@ -135,7 +135,7 @@ contract MultiSigSigner is ISigner {
                 IDelegation(msg.sender).unwrapAndValidateSignature(digest, signatures[i]);
 
             if (!isValid) {
-                return FAIL_VALUE;
+                continue;
             }
 
             uint256 j;

--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -129,6 +129,7 @@ contract MultiSigSigner is ISigner {
     ///   for each owner key hash in the config.
     /// - Signature of a multi-sig should be encoded as abi.encode(bytes[] memory ownerSignatures)
     /// - For efficiency, place the signatures in the same order as the ownerKeyHashes in the config.
+    /// - Failing owner signatures are ignored, as long as valid signaturs > threshold.
     function isValidSignatureWithKeyHash(bytes32 digest, bytes32 keyHash, bytes memory signature)
         public
         view

--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {IDelegation} from "./interfaces/IDelegation.sol";
+
+contract MultiSigSigner {
+    // bytes4(keccak256("isValidSignatureWithKeyHash(bytes32,bytes32,bytes)")
+    bytes4 internal constant MAGIC_VALUE = 0x8afc93b4;
+
+    bytes4 internal constant FAIL_VALUE = 0xffffffff;
+
+    /// @dev The threshold can't be zero.
+    error InvalidThreshold();
+
+    ////////////////////////////////////////////////////////////////////////
+    // Storage
+    ////////////////////////////////////////////////////////////////////////
+
+    struct Config {
+        uint256 threshold;
+        bytes32[] keyHashes;
+    }
+
+    mapping(address => mapping(bytes32 => Config)) public configs;
+
+    function setConfig(bytes32 keyHash, uint256 threshold, bytes32[] memory keyHashes) public {
+        // Threshold can't be zero
+        if (threshold == 0) revert InvalidThreshold();
+
+        configs[msg.sender][keyHash] = Config({threshold: threshold, keyHashes: keyHashes});
+    }
+
+    function addOwner(bytes32 keyHash, bytes32 ownerKeyHash) public {
+        Config storage config = configs[msg.sender][keyHash];
+        config.keyHashes.push(ownerKeyHash);
+    }
+
+    function removeOwner(bytes32 keyHash, bytes32 ownerKeyHash) public {}
+
+    function setThreshold(bytes32 keyHash, uint256 threshold) public {
+        // Threshold can't be zero
+        if (threshold == 0) revert InvalidThreshold();
+
+        Config storage config = configs[msg.sender][keyHash];
+        config.threshold = threshold;
+    }
+
+    /// @dev This function should only be called by valid Delegation porto accounts.
+    /// This will iteratively make a call to the `unwrapAndValidateSignature` function of the msg.sender
+    function isValidSignatureWithKeyHash(bytes32 digest, bytes32 keyHash, bytes memory signature)
+        public
+        view
+        returns (bytes4 magicValue)
+    {
+        bytes[] memory signatures = abi.decode(signature, (bytes[]));
+        Config memory config = configs[msg.sender][keyHash];
+
+        uint256 validKeyNum;
+
+        for (uint256 i; i < signatures.length; ++i) {
+            (bool v, bytes32 k) =
+                IDelegation(msg.sender).unwrapAndValidateSignature(digest, signatures[i]);
+
+            if (!v) {
+                return FAIL_VALUE;
+            }
+
+            uint256 j;
+            while (j < config.keyHashes.length) {
+                if (config.keyHashes[j] == k) {
+                    // Incrementing validKeyNum
+                    validKeyNum++;
+                    config.keyHashes[j] = bytes32(0);
+
+                    if (validKeyNum == config.threshold) {
+                        return MAGIC_VALUE;
+                    }
+
+                    break;
+                }
+
+                unchecked {
+                    j++;
+                }
+            }
+
+            // This means that the keyHash was not found
+            if (j == config.keyHashes.length) {
+                return FAIL_VALUE;
+            }
+        }
+
+        // If we reach here, then the required threshold was not met.
+        return FAIL_VALUE;
+    }
+}

--- a/src/interfaces/IDelegation.sol
+++ b/src/interfaces/IDelegation.sol
@@ -32,6 +32,7 @@ interface IDelegation is ICommon {
     /// @dev Return current nonce with sequence key.
     function getNonce(uint192 seqKey) external view returns (uint256 nonce);
 
-    /// @dev Return the key hash of the current context.
+    /// @dev Return the key hash that signed the latest execution context.
+    /// @dev Returns bytes32(0) if the EOA key was used.
     function getContextKeyHash() external view returns (bytes32);
 }

--- a/src/interfaces/IDelegation.sol
+++ b/src/interfaces/IDelegation.sol
@@ -31,4 +31,7 @@ interface IDelegation is ICommon {
 
     /// @dev Return current nonce with sequence key.
     function getNonce(uint192 seqKey) external view returns (uint256 nonce);
+
+    /// @dev Return the key hash of the current context.
+    function getContextKeyHash() external view returns (bytes32);
 }

--- a/src/interfaces/ISigner.sol
+++ b/src/interfaces/ISigner.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+/// @notice Interface that MUST be implemented by all contracts, that want to verify signatures
+/// using the `External` keytype in a Delegation account.
 interface ISigner {
+    /// @dev MUST return the magic value `0x8afc93b4` if the signature is valid.
     function isValidSignatureWithKeyHash(bytes32 digest, bytes32 keyHash, bytes memory signature)
         external
         view

--- a/src/interfaces/ISigner.sol
+++ b/src/interfaces/ISigner.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+interface ISigner {
+    function isValidSignatureWithKeyHash(bytes32 digest, bytes32 keyHash, bytes memory signature)
+        external
+        view
+        returns (bytes4 magicValue);
+}

--- a/src/libraries/LibMultiSig.sol
+++ b/src/libraries/LibMultiSig.sol
@@ -1,0 +1,7 @@
+// // SPDX-License-Identifier: MIT
+// pragma solidity ^0.8.23;
+
+// library LibMultiSig {
+
+//     function verifyMultiSig()
+// }

--- a/src/libraries/LibMultiSig.sol
+++ b/src/libraries/LibMultiSig.sol
@@ -1,7 +1,0 @@
-// // SPDX-License-Identifier: MIT
-// pragma solidity ^0.8.23;
-
-// library LibMultiSig {
-
-//     function verifyMultiSig()
-// }

--- a/src/libraries/LibTStack.sol
+++ b/src/libraries/LibTStack.sol
@@ -10,60 +10,25 @@ library LibTStack {
         t.slot = tSlot;
     }
 
-    function top(TStack memory t) internal view returns (bytes32) {
+    function top(TStack memory t) internal view returns (bytes32 val) {
         uint256 tSlot = t.slot;
 
         assembly ("memory-safe") {
             let len := tload(tSlot)
             if iszero(len) {
-                mstore(0x00, 0x00)
-                return(0x00, 0x20)
+                mstore(0x00, 0xbc7ec779) // `EmptyStack()`
+                revert(0x1c, 0x04)
             }
 
-            mstore(0x00, tload(add(tSlot, len)))
-
-            return(0x00, 0x20)
+            val := tload(add(tSlot, len))
         }
     }
 
-    function get(TStack memory t, uint256 index) internal view returns (bytes32) {
+    function size(TStack memory t) internal view returns (uint256 len) {
         uint256 tSlot = t.slot;
 
         assembly ("memory-safe") {
-            let len := tload(tSlot)
-
-            if lt(index, len) {
-                mstore(0x00, tload(add(tSlot, add(index, 1))))
-                return(0x00, 0x20)
-            }
-
-            mstore(0x00, 0xb4120f14) // `OutOfBounds()`
-            revert(0x1c, 0x04)
-        }
-    }
-
-    function set(TStack memory t, uint256 index, bytes32 val) internal {
-        uint256 tSlot = t.slot;
-
-        assembly ("memory-safe") {
-            let len := tload(tSlot)
-
-            if lt(index, len) {
-                tstore(add(tSlot, add(index, 1)), val)
-                return(0x00, 0x00)
-            }
-
-            mstore(0x00, 0xb4120f14) // `OutOfBounds()`
-            revert(0x1c, 0x04)
-        }
-    }
-
-    function size(TStack memory t) internal view returns (uint256) {
-        uint256 tSlot = t.slot;
-
-        assembly ("memory-safe") {
-            mstore(0x00, tload(tSlot))
-            return(0x00, 0x20)
+            len := tload(tSlot)
         }
     }
 
@@ -71,18 +36,57 @@ library LibTStack {
         uint256 tSlot = t.slot;
 
         assembly ("memory-safe") {
-            let len := tload(tSlot)
+            let len := add(tload(tSlot), 1)
             tstore(add(tSlot, len), val)
-            tstore(tSlot, add(len, 1))
+            tstore(tSlot, len)
         }
     }
 
+    /// @dev Does NOT clean the value on top of the stack automatically.
     function pop(TStack memory t) internal {
         uint256 tSlot = t.slot;
 
         assembly ("memory-safe") {
             let len := tload(tSlot)
+            if iszero(len) {
+                mstore(0x00, 0xbc7ec779) // `EmptyStack()`
+                revert(0x1c, 0x04)
+            }
+
             tstore(tSlot, sub(len, 1))
         }
     }
+
+    // Functions for feature completeness, that we don't need in the account.(UNTESTED)
+    // function get(TStack memory t, uint256 index) internal view returns (bytes32) {
+    //     uint256 tSlot = t.slot;
+
+    //     assembly ("memory-safe") {
+    //         let len := tload(tSlot)
+
+    //         if lt(index, len) {
+    //             mstore(0x00, tload(add(tSlot, add(index, 1))))
+    //             return(0x00, 0x20)
+    //         }
+
+    //         mstore(0x00, 0xb4120f14) // `OutOfBounds()`
+    //         revert(0x1c, 0x04)
+    //     }
+    // }
+
+    // function set(TStack memory t, uint256 index, bytes32 val) internal {
+    //     uint256 tSlot = t.slot;
+
+    //     assembly ("memory-safe") {
+    //         let len := tload(tSlot)
+
+    //         if lt(index, len) {
+    //             tstore(add(tSlot, add(index, 1)), val)
+    //             return(0x00, 0x00)
+    //         }
+
+    //         mstore(0x00, 0xb4120f14) // `OutOfBounds()`
+    //         revert(0x1c, 0x04)
+    //     }
+    // }
 }

--- a/src/libraries/LibTStack.sol
+++ b/src/libraries/LibTStack.sol
@@ -1,7 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+/// @notice A minimal bytes32 stack implementation in transient storage.
 library LibTStack {
+    /// @dev Helper struct to store the base slot of the stack.
     struct TStack {
         uint256 slot;
     }
@@ -10,6 +12,8 @@ library LibTStack {
         t.slot = tSlot;
     }
 
+    /// @dev Returns the top-most value of the stack.
+    /// Throws an `EmptyStack()` error if the stack is empty.
     function top(TStack memory t) internal view returns (bytes32 val) {
         uint256 tSlot = t.slot;
 
@@ -24,6 +28,7 @@ library LibTStack {
         }
     }
 
+    /// @dev Returns the size of the stack.
     function size(TStack memory t) internal view returns (uint256 len) {
         uint256 tSlot = t.slot;
 
@@ -32,6 +37,7 @@ library LibTStack {
         }
     }
 
+    /// @dev Pushes a bytes32 value to the top of the stack.
     function push(TStack memory t, bytes32 val) internal {
         uint256 tSlot = t.slot;
 
@@ -42,6 +48,8 @@ library LibTStack {
         }
     }
 
+    /// @dev Pops the top-most value from the stack.
+    /// Throws an `EmptyStack()` error if the stack is empty.
     /// @dev Does NOT clean the value on top of the stack automatically.
     function pop(TStack memory t) internal {
         uint256 tSlot = t.slot;
@@ -56,37 +64,4 @@ library LibTStack {
             tstore(tSlot, sub(len, 1))
         }
     }
-
-    // Functions for feature completeness, that we don't need in the account.(UNTESTED)
-    // function get(TStack memory t, uint256 index) internal view returns (bytes32) {
-    //     uint256 tSlot = t.slot;
-
-    //     assembly ("memory-safe") {
-    //         let len := tload(tSlot)
-
-    //         if lt(index, len) {
-    //             mstore(0x00, tload(add(tSlot, add(index, 1))))
-    //             return(0x00, 0x20)
-    //         }
-
-    //         mstore(0x00, 0xb4120f14) // `OutOfBounds()`
-    //         revert(0x1c, 0x04)
-    //     }
-    // }
-
-    // function set(TStack memory t, uint256 index, bytes32 val) internal {
-    //     uint256 tSlot = t.slot;
-
-    //     assembly ("memory-safe") {
-    //         let len := tload(tSlot)
-
-    //         if lt(index, len) {
-    //             tstore(add(tSlot, add(index, 1)), val)
-    //             return(0x00, 0x00)
-    //         }
-
-    //         mstore(0x00, 0xb4120f14) // `OutOfBounds()`
-    //         revert(0x1c, 0x04)
-    //     }
-    // }
 }

--- a/src/libraries/LibTStack.sol
+++ b/src/libraries/LibTStack.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+library LibTStack {
+    struct TStack {
+        uint256 slot;
+    }
+
+    function tStack(uint256 tSlot) internal pure returns (TStack memory t) {
+        t.slot = tSlot;
+    }
+
+    function top(TStack memory t) internal view returns (bytes32) {
+        uint256 tSlot = t.slot;
+
+        assembly ("memory-safe") {
+            let len := tload(tSlot)
+            if iszero(len) {
+                mstore(0x00, 0x00)
+                return(0x00, 0x20)
+            }
+
+            mstore(0x00, tload(add(tSlot, len)))
+
+            return(0x00, 0x20)
+        }
+    }
+
+    function get(TStack memory t, uint256 index) internal view returns (bytes32) {
+        uint256 tSlot = t.slot;
+
+        assembly ("memory-safe") {
+            let len := tload(tSlot)
+
+            if lt(index, len) {
+                mstore(0x00, tload(add(tSlot, add(index, 1))))
+                return(0x00, 0x20)
+            }
+
+            mstore(0x00, 0xb4120f14) // `OutOfBounds()`
+            revert(0x1c, 0x04)
+        }
+    }
+
+    function set(TStack memory t, uint256 index, bytes32 val) internal {
+        uint256 tSlot = t.slot;
+
+        assembly ("memory-safe") {
+            let len := tload(tSlot)
+
+            if lt(index, len) {
+                tstore(add(tSlot, add(index, 1)), val)
+                return(0x00, 0x00)
+            }
+
+            mstore(0x00, 0xb4120f14) // `OutOfBounds()`
+            revert(0x1c, 0x04)
+        }
+    }
+
+    function size(TStack memory t) internal view returns (uint256) {
+        uint256 tSlot = t.slot;
+
+        assembly ("memory-safe") {
+            mstore(0x00, tload(tSlot))
+            return(0x00, 0x20)
+        }
+    }
+
+    function push(TStack memory t, bytes32 val) internal {
+        uint256 tSlot = t.slot;
+
+        assembly ("memory-safe") {
+            let len := tload(tSlot)
+            tstore(add(tSlot, len), val)
+            tstore(tSlot, add(len, 1))
+        }
+    }
+
+    function pop(TStack memory t) internal {
+        uint256 tSlot = t.slot;
+
+        assembly ("memory-safe") {
+            let len := tload(tSlot)
+            tstore(tSlot, sub(len, 1))
+        }
+    }
+}

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -120,10 +120,7 @@ contract BaseTest is SoladyTest {
         k.keyHash = _hash(k.k);
     }
 
-    function _randomKey()
-        internal
-        returns (Delegation.Key memory k, Delegation.KeyExtraStorage memory e)
-    {
+    function _randomKey() internal returns (Delegation.Key memory k) {
         k.keyType = Delegation.KeyType(uint8(_bound(_random(), 0, 3)));
         k.isSuperAdmin = _randomChance(2);
         k.publicKey = abi.encode(address(_randomUniqueHashedAddress()));

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -188,6 +188,22 @@ contract BaseTest is SoladyTest {
         return _multiSig(k, _hash(k.k), false, digest);
     }
 
+    function _sig(MultiSigKey memory k, EntryPoint.UserOp memory u)
+        internal
+        view
+        returns (bytes memory)
+    {
+        return _multiSig(k, _hash(k.k), false, ep.computeDigest(u));
+    }
+
+    function _sig(MultiSigKey memory k, bool prehash, bytes32 digest)
+        internal
+        pure
+        returns (bytes memory)
+    {
+        return _multiSig(k, _hash(k.k), prehash, digest);
+    }
+
     function _secp256r1Sig(uint256 privateKey, bytes32 keyHash, bytes32 digest)
         internal
         pure
@@ -232,6 +248,7 @@ contract BaseTest is SoladyTest {
         for (uint256 i; i < k.threshold; ++i) {
             signatures[i] = _sig(k.owners[i], digest);
         }
+
         return abi.encodePacked(abi.encode(signatures), keyHash, uint8(preHash ? 1 : 0));
     }
 
@@ -275,6 +292,13 @@ contract BaseTest is SoladyTest {
         u.signature = abi.encodePacked(keccak256("a"), keccak256("b"), keyHash, uint8(0));
 
         return _estimateGas(u);
+    }
+
+    function _estimateGasForMultiSigKey(MultiSigKey memory k, EntryPoint.UserOp memory u)
+        internal
+        returns (uint256 gExecute, uint256 gCombined, uint256 gUsed)
+    {
+        return _estimateGas(u, true, 1, 11_000, 10_000 * k.threshold);
     }
 
     function _estimateGas(EntryPoint.UserOp memory u)

--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -120,6 +120,16 @@ contract BaseTest is SoladyTest {
         k.keyHash = _hash(k.k);
     }
 
+    function _randomKey()
+        internal
+        returns (Delegation.Key memory k, Delegation.KeyExtraStorage memory e)
+    {
+        k.keyType = Delegation.KeyType(uint8(_bound(_random(), 0, 3)));
+        k.isSuperAdmin = _randomChance(2);
+        k.publicKey = abi.encode(address(_randomUniqueHashedAddress()));
+        k.expiry = 0;
+    }
+
     function _sig(DelegatedEOA memory d, EntryPoint.UserOp memory u)
         internal
         view

--- a/test/EntryPoint.t.sol
+++ b/test/EntryPoint.t.sol
@@ -123,7 +123,7 @@ contract EntryPointTest is BaseTest {
         paymentToken.mint(d.eoa, 50 ether);
 
         _simulateExecute(
-            _SimulateExecuteParams({
+            _EstimateGasParams({
                 u: u,
                 isPrePayment: false,
                 paymentPerGasPrecision: 0,
@@ -189,7 +189,7 @@ contract EntryPointTest is BaseTest {
         u.signature = _sig(d, u);
 
         _simulateExecute(
-            _SimulateExecuteParams({
+            _EstimateGasParams({
                 u: u,
                 isPrePayment: false,
                 paymentPerGasPrecision: 0,
@@ -296,7 +296,7 @@ contract EntryPointTest is BaseTest {
         vm.expectRevert(bytes4(keccak256("PaymentError()")));
 
         _simulateExecute(
-            _SimulateExecuteParams({
+            _EstimateGasParams({
                 u: u,
                 isPrePayment: false,
                 paymentPerGasPrecision: 0,
@@ -433,16 +433,7 @@ contract EntryPointTest is BaseTest {
         }
     }
 
-    struct _SimulateExecuteParams {
-        EntryPoint.UserOp u;
-        bool isPrePayment;
-        uint8 paymentPerGasPrecision;
-        uint256 paymentPerGas;
-        uint256 combinedGasIncrement;
-        uint256 combinedGasVerificationOffset;
-    }
-
-    function _simulateExecute(_SimulateExecuteParams memory p)
+    function _simulateExecute(_EstimateGasParams memory p)
         internal
         returns (uint256 gUsed, uint256 gCombined)
     {
@@ -790,7 +781,7 @@ contract EntryPointTest is BaseTest {
 
         vm.expectRevert(bytes4(keccak256("Unauthorized()")));
         _simulateExecute(
-            _SimulateExecuteParams({
+            _EstimateGasParams({
                 u: u,
                 isPrePayment: false,
                 paymentPerGasPrecision: 0,
@@ -1035,7 +1026,7 @@ contract EntryPointTest is BaseTest {
             to: address(t.multiSigSigner),
             value: 0,
             data: abi.encodeWithSelector(
-                MultiSigSigner.setConfig.selector,
+                MultiSigSigner.initConfig.selector,
                 _hash(t.multiSigKey.k),
                 t.multiSigKey.threshold,
                 ownerKeyHashes
@@ -1053,7 +1044,7 @@ contract EntryPointTest is BaseTest {
         // Try to set config again
         vm.startPrank(t.d.eoa);
         vm.expectRevert(bytes4(keccak256("ConfigAlreadySet()")));
-        t.multiSigSigner.setConfig(_hash(t.multiSigKey.k), 5, ownerKeyHashes);
+        t.multiSigSigner.initConfig(_hash(t.multiSigKey.k), 5, ownerKeyHashes);
         vm.stopPrank();
 
         calls[0] = ERC7821.Call({

--- a/test/LibTStack.t.sol
+++ b/test/LibTStack.t.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.23;
 
 import {LibTStack} from "../src/libraries/LibTStack.sol";
 import {BaseTest} from "./Base.t.sol";
-import "forge-std/console.sol";
 
 contract LibTStackTest is BaseTest {
     using LibTStack for LibTStack.TStack;

--- a/test/LibTStack.t.sol
+++ b/test/LibTStack.t.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.23;
+
+import {LibTStack} from "../src/libraries/LibTStack.sol";
+import {BaseTest} from "./Base.t.sol";
+import "forge-std/console.sol";
+
+contract LibTStackTest is BaseTest {
+    using LibTStack for LibTStack.TStack;
+
+    function _fillStack(LibTStack.TStack memory t) public {
+        uint256 len = _bound(_random(), 0, 256);
+
+        for (uint256 i; i < len; ++i) {
+            bytes32 val = bytes32(_random());
+            t.push(val);
+
+            assertEq(t.top(), val);
+            assertEq(t.size(), i + 1);
+        }
+
+        assertEq(t.size(), len);
+    }
+
+    function test_push(bytes32) public {
+        LibTStack.TStack memory t = LibTStack.tStack(_random());
+
+        _fillStack(t);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_top(bytes32) public {
+        LibTStack.TStack memory t = LibTStack.tStack(_random());
+
+        bytes32 top = bytes32(_random());
+        t.push(top);
+
+        assertEq(t.top(), top);
+
+        bytes32 topCache = top;
+        top = bytes32(_random());
+        t.push(top);
+
+        assertEq(t.top(), top);
+
+        t.pop();
+
+        assertEq(t.top(), topCache);
+
+        t.pop();
+
+        assertEq(t.size(), 0);
+        vm.expectRevert(bytes4(keccak256("EmptyStack()")));
+        LibTStack.top(t);
+    }
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_pop(bytes32) public {
+        LibTStack.TStack memory t = LibTStack.tStack(_random());
+
+        _fillStack(t);
+
+        if (t.size() == 0) {
+            vm.expectRevert(bytes4(keccak256("EmptyStack()")));
+            t.pop();
+        } else {
+            uint256 len = t.size();
+            for (uint256 i; i < len; ++i) {
+                t.pop();
+                assertEq(t.size(), len - i - 1);
+            }
+
+            assertEq(t.size(), 0);
+            vm.expectRevert(bytes4(keccak256("EmptyStack()")));
+            t.pop();
+        }
+    }
+}


### PR DESCRIPTION
### Features
- Adds support for `External` keytype. Which allows external contracts that implement the `ISigner` 
  to verify signatures. 
- Adds a `MultiSigSigner` which adds multi-sig support to the account, using `External` keytype.#151 
- Adds a stack of `context key hashes` to the account. External observers can check which key signed
  the account's current execution, by calling the `getContextKeyHash` function on the msg.sender.
  This has a variety of usecases like validating key operations, setting data in account registry etc.
  This mechanism can also be used to solve #154 
- Only adds features. Should not have breaking changes for @relay.

