### PR TITLE
Remove PK env from deploy script

### DIFF
--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -6,8 +6,7 @@ import "../src/DeployAll.sol";
 
 contract DeployAllScript is Script {
     function run() external {
-        uint256 deployerPrivateKey = vm.envUint("PRIVATE_KEY");
-        vm.startBroadcast(deployerPrivateKey);
+        vm.startBroadcast();
         new DeployAll();
         vm.stopBroadcast();
     }


### PR DESCRIPTION
PR removes PK env variable from deploy all 

Tested: deploy ci still works bc it is setting the deployer key already https://github.com/ithacaxyz/account/actions/runs/15026063535 