### PR TITLE
Catch Payment Errors in Simulate Loop

### DIFF
--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -177,7 +177,10 @@ contract Simulator {
                 if iszero(gasUsed) {
                     let m := mload(0x40)
                     returndatacopy(m, 0x00, returndatasize())
-                    revert(m, returndatasize())
+                    // `PaymentError` is given special treatment here, as it comes from
+                    // the account not having enough funds, and cannot be recovered from,
+                    // since the paymentAmount will keep increasing in this loop.
+                    if eq(shr(224, mload(0x00)), 0xabab8fc9) { revert(m, 32) }
                 }
             }
 

--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -172,6 +172,15 @@ contract Simulator {
         while (true) {
             gasUsed = _callEntryPointMemory(ep, false, 0, u);
 
+            // If the simulation failed, bubble up the full revert.
+            assembly ("memory-safe") {
+                if iszero(gasUsed) {
+                    let m := mload(0x40)
+                    returndatacopy(m, 0x00, returndatasize())
+                    revert(m, returndatasize())
+                }
+            }
+
             if (gasUsed != 0) {
                 return (gasUsed, u.combinedGas);
             }

--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -180,7 +180,7 @@ contract Simulator {
                     // `PaymentError` is given special treatment here, as it comes from
                     // the account not having enough funds, and cannot be recovered from,
                     // since the paymentAmount will keep increasing in this loop.
-                    if eq(shr(224, mload(0x00)), 0xabab8fc9) { revert(m, 32) }
+                    if eq(shr(224, mload(m)), 0xabab8fc9) { revert(m, 0x20) }
                 }
             }
 

--- a/test/SimulateExecute.t.sol
+++ b/test/SimulateExecute.t.sol
@@ -136,7 +136,6 @@ contract SimulateExecuteTest is BaseTest {
         u.totalPaymentAmount = u.prePaymentAmount;
         u.totalPaymentMaxAmount = u.prePaymentMaxAmount;
         u.combinedGas = 20_000;
-        // u.paymentPerGas = 1;
 
         {
             // Just pass in a junk secp256k1 signature.
@@ -145,12 +144,12 @@ contract SimulateExecuteTest is BaseTest {
             u.signature = abi.encodePacked(r, s, v);
         }
 
-        address maxBalanceCaller = _randomUniqueHashedAddress();
-        vm.deal(maxBalanceCaller, type(uint256).max);
-        vm.prank(maxBalanceCaller);
         vm.expectRevert(bytes4(keccak256("PaymentError()")));
-        (t.gUsed, t.gCombined) =
-            simulator.simulateV1Logs(address(ep), false, 1, 11_000, 0, abi.encode(u));
+        simulator.simulateV1Logs(address(ep), false, 1, 11_000, 0, abi.encode(u));
+
+        deal(u.paymentToken, address(u.eoa), 0x112233112233112233112233);
+        vm.expectRevert(bytes4(keccak256("PaymentError()")));
+        simulator.simulateCombinedGas(address(ep), true, 1, 11_000, abi.encode(u));
     }
 
     function testSimulateExecuteNoRevert() public {


### PR DESCRIPTION
In the combinedGas loop, the payment is also incremented along with the combined gas.
There might come a point, where the user does not have enough funds for the payment. The user cannot recover from this, so we revert in the loop.
