### PR TITLE
feat: forever period to GuardedExecutor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,4 +4,3 @@
 [submodule "lib/solady"]
 	path = lib/solady
 	url = https://github.com/vectorized/solady
-	branch = main

--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -37,7 +37,8 @@ abstract contract GuardedExecutor is ERC7821 {
         Day,
         Week,
         Month,
-        Year
+        Year,
+        Forever
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -527,6 +528,7 @@ abstract contract GuardedExecutor is ERC7821 {
         // Note: DateTimeLib's months and month-days start from 1.
         if (period == SpendPeriod.Month) return DateTimeLib.dateToTimestamp(year, month, 1);
         if (period == SpendPeriod.Year) return DateTimeLib.dateToTimestamp(year, 1, 1);
+        if (period == SpendPeriod.Forever) return 1; // Non-zero to differentiate from not set.
         revert(); // We shouldn't hit here.
     }
 


### PR DESCRIPTION
**Use case:**

App asks user to authorize some session key that is authorize to pull a fixed amount of assets _only once_. 

The pulled assets could then go into some sub account where some bot could run automated trading on.

**Note:**

Due to the whitelist nature of our spend limits, a trading bot cannot work directly on the EOA using a P256 key. Say if it has swapped 1000 USDC to some memecoin, a separate spend permission has to be granted by a superAdmin to swap that memecoin out to sell. Granting superAdmins is a very risky move. The way around this is sub accounts.