### PR TITLE
Fix delegationImplementationOf test with optimizer turned off + fix forge coverage

### DIFF
--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.4;
 
 import "./utils/SoladyTest.sol";
 import {EIP7702Proxy} from "solady/accounts/EIP7702Proxy.sol";
+import {LibEIP7702} from "solady/accounts/LibEIP7702.sol";
 import {ERC7821} from "solady/accounts/ERC7821.sol";
 import {LibERC7579} from "solady/accounts/LibERC7579.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
@@ -72,7 +73,8 @@ contract BaseTest is SoladyTest {
         ep = new MockEntryPoint(address(this));
         paymentToken = new MockPaymentToken();
         delegationImplementation = address(new MockDelegation(address(ep)));
-        eip7702Proxy = new EIP7702Proxy(delegationImplementation, address(this));
+        eip7702Proxy =
+            EIP7702Proxy(payable(LibEIP7702.deployProxy(delegationImplementation, address(this))));
         delegation = MockDelegation(payable(eip7702Proxy));
         simulator = new Simulator();
 


### PR DESCRIPTION
Fixes https://github.com/ithacaxyz/account/issues/150

I was browsing through the repo and got nerd-sniped to look into this. The function that returns the delegation and implementation is implemented with Solady's `LibEIP7702.delegationAndImplementationOf();`:
https://github.com/ithacaxyz/account/blob/210ca4bf53aa7e26224edf2b36365a390fc4bdd6/src/EntryPoint.sol#L635-L641

which internally verifies the hash of the runtime bytecode of the proxy:
https://github.com/vectorized/solady/blob/d7469ddff36d90beac6587ddb5128337c14e7df6/src/accounts/LibEIP7702.sol#L99-L112

and the proxy itself is deployed in `Base.t.sol` with the `new` keyword, which means that the bytecode that gets deployed is affected by the project's compiler settings:
https://github.com/ithacaxyz/account/blob/210ca4bf53aa7e26224edf2b36365a390fc4bdd6/test/Base.t.sol#L71-L80

So switching compiler settings would make `isEIP7702Proxy` check fail and return zero address, failing the test.

The LibEIP7702.sol has helper functions that deploy proxies using fixed bytecode, and this PR switches the tests to use that.