### PR TITLE
Refactor EIP7702Proxy instantiation to use LibEIP7702 for proxy deployment in tests

### DIFF
--- a/test/Base.t.sol
+++ b/test/Base.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.4;
 
 import "./utils/SoladyTest.sol";
 import {EIP7702Proxy} from "solady/accounts/EIP7702Proxy.sol";
+import {LibEIP7702} from "solady/accounts/LibEIP7702.sol";
 import {ERC7821} from "solady/accounts/ERC7821.sol";
 import {LibERC7579} from "solady/accounts/LibERC7579.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
@@ -72,7 +73,8 @@ contract BaseTest is SoladyTest {
         ep = new MockEntryPoint(address(this));
         paymentToken = new MockPaymentToken();
         delegationImplementation = address(new MockDelegation(address(ep)));
-        eip7702Proxy = new EIP7702Proxy(delegationImplementation, address(this));
+        eip7702Proxy =
+            EIP7702Proxy(payable(LibEIP7702.deployProxy(delegationImplementation, address(this))));
         delegation = MockDelegation(payable(eip7702Proxy));
         simulator = new Simulator();
 

--- a/test/Benchmark.t.sol
+++ b/test/Benchmark.t.sol
@@ -10,6 +10,7 @@ import {MockERC4337Account, ERC4337} from "./utils/mocks/MockERC4337Account.sol"
 import {SignatureCheckerLib} from "solady/utils/SignatureCheckerLib.sol";
 import {SafeTransferLib} from "solady/utils/SafeTransferLib.sol";
 import {LibClone} from "solady/utils/LibClone.sol";
+import {LibEIP7702} from "solady/accounts/LibEIP7702.sol";
 
 interface IUniswapV2Router {
     function addLiquidity(
@@ -51,7 +52,9 @@ contract BenchmarkTest is BaseTest {
         super.setUp();
 
         // re-setup the EIP7702Proxy to have no admin, like in production, for efficiency.
-        eip7702Proxy = new EIP7702Proxy(address(new MockDelegation(address(ep))), address(0));
+        eip7702Proxy = EIP7702Proxy(
+            payable(LibEIP7702.deployProxy(address(new MockDelegation(address(ep))), address(0)))
+        );
         delegation = MockDelegation(payable(eip7702Proxy));
 
         vm.etch(
@@ -335,7 +338,9 @@ contract BenchmarkTest is BaseTest {
     function testERC20TransferViaMinimals() public {
         vm.pauseGasMetering();
 
-        eip7702Proxy = new EIP7702Proxy(address(new MockMinimalDelegation()), address(0));
+        eip7702Proxy = EIP7702Proxy(
+            payable(LibEIP7702.deployProxy(address(new MockMinimalDelegation()), address(0)))
+        );
         delegation = MockDelegation(payable(eip7702Proxy));
 
         MockMinimalEntryPoint epMinimal = new MockMinimalEntryPoint();

--- a/test/Delegation.t.sol
+++ b/test/Delegation.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.4;
 import "./utils/SoladyTest.sol";
 import "./Base.t.sol";
 import {MockSampleDelegateCallTarget} from "./utils/mocks/MockSampleDelegateCallTarget.sol";
+import {LibEIP7702} from "solady/accounts/LibEIP7702.sol";
 
 contract DelegationTest is BaseTest {
     struct _TestExecuteWithSignatureTemps {
@@ -309,7 +310,8 @@ contract DelegationTest is BaseTest {
     function testAddDisallowedSuperAdminKeyTypeReverts() public {
         address entryPoint = address(new EntryPoint(address(this)));
         address delegationImplementation = address(new Delegation(address(entryPoint)));
-        address delegationProxy = address(new EIP7702Proxy(delegationImplementation, address(0)));
+        address delegationProxy =
+            address(LibEIP7702.deployProxy(delegationImplementation, address(0)));
         delegation = MockDelegation(payable(delegationProxy));
 
         DelegatedEOA memory d = _randomEIP7702DelegatedEOA();


### PR DESCRIPTION
A follow-up to https://github.com/ithacaxyz/account/pull/162 to prevent similar issues when switching compiler settings