### PR TITLE
fix: correct bug-bounty.md 404 link reference

### DIFF
--- a/docs/bug-bounty.md
+++ b/docs/bug-bounty.md
@@ -10,7 +10,7 @@ We're opening up a live bug bounty program to encourage responsible security res
 
 **Porto Address:** `0xb4B87c22950eD0f3D83aabd3dE20009bA9b16DF1`  
 **Chain ID:** `8453`  
-**Deployed Version:** [`v0.2.0`](https://github.com/IthacaLabs/porto/releases/tag/v0.2.0)
+**Deployed Version:** [`v0.2.0`](https://github.com/ithacaxyz/account/releases/tag/v0.2.0)
 
 ---
 


### PR DESCRIPTION
Description:
This PR fixes a 404 broken link in the bug-bounty.md file. The link was incorrectly pointing to a non-existent tag in the porto repository, while it should be pointing to the account repository instead.

Changed from:
https://github.com/IthacaLabs/porto/releases/tag/v0.2.0

Changed to:
https://github.com/ithacaxyz/account/releases/tag/v0.2.0

This ensures that users can properly access the referenced deployment commit mentioned in the bug bounty documentation.