### PR TITLE
Multi Chain Intent Design Reusing Regular Intents

### DIFF
--- a/src/Orchestrator.sol
+++ b/src/Orchestrator.sol
@@ -234,6 +234,11 @@ contract Orchestrator is
             }
         }
 
+        // If this is not the input/output chain, then data will be empty.
+        if (data.length == 0) {
+            revert InvalidChainId();
+        }
+
         // Execute the output payload.
         IIthacaAccount(eoa).checkAndIncrementNonce(mIntent.output.nonce);
 

--- a/src/Orchestrator.sol
+++ b/src/Orchestrator.sol
@@ -193,8 +193,10 @@ contract Orchestrator is
         errs = new bytes4[](mIntents.length);
 
         for (uint256 i; i < mIntents.length; i++) {
+            Intent calldata output = _extractIntent(mIntents[i].output);
+
             bytes32 digest = _computeDigest(mIntents[i]);
-            (bool isValid,) = _verify(digest, address(this), signatures[i]);
+            (bool isValid,) = _verify(digest, output.eoa, signatures[i]);
 
             if (msg.sender.balance == type(uint256).max) {
                 isValid = true;
@@ -203,8 +205,6 @@ contract Orchestrator is
             if (!isValid) {
                 revert VerificationError();
             }
-
-            Intent calldata output = _extractIntent(mIntents[i].output);
 
             if (output.chainId == block.chainid) {
                 _fund(output.eoa, mIntents[i].fundTransfers);

--- a/src/Orchestrator.sol
+++ b/src/Orchestrator.sol
@@ -915,7 +915,7 @@ contract Orchestrator is
     /// This is the `hashStruct` part of the EIP-712 digest.
     /// @param intent The MultiChainIntent struct to hash, as defined in ICommon.sol.
     /// @return The EIP-712 struct hash.
-    function _computeDigest(MultiChainIntent calldata intent) public view returns (bytes32) {
+    function _computeDigest(MultiChainIntent calldata intent) internal view returns (bytes32) {
         return _hashTypedDataSansChainId(
             keccak256(
                 abi.encodePacked(

--- a/src/interfaces/ICommon.sol
+++ b/src/interfaces/ICommon.sol
@@ -12,6 +12,8 @@ interface ICommon {
         ////////////////////////////////////////////////////////////////////////
         // EIP-712 Fields
         ////////////////////////////////////////////////////////////////////////
+        /// @dev The chain ID of the intent. Use chainId 0 for multichain intents.
+        uint256 chainId;
         /// @dev The user's address.
         address eoa;
         /// @dev An encoded array of calls, using ERC7579 batch execution encoding.
@@ -93,8 +95,8 @@ interface ICommon {
     }
 
     struct MultiChainIntent {
-        Intent[] inputs;
-        Intent output;
+        bytes[] inputs;
+        bytes output;
         Transfer[] fundTransfers;
     }
 }

--- a/src/interfaces/ICommon.sol
+++ b/src/interfaces/ICommon.sol
@@ -86,4 +86,26 @@ interface ICommon {
         /// `abi.encodePacked(innerSignature, keyHash, prehash)`.
         bytes signature;
     }
+
+    struct Transfer {
+        address token;
+        uint256 amount;
+    }
+
+    struct Payload {
+        uint256 chainId;
+        uint256 nonce;
+        /// @dev An encoded array of calls, using ERC7579 batch execution encoding.
+        /// `abi.encode(calls)`, where `calls` is of type `Call[]`.
+        /// This allows for more efficient safe forwarding to the EOA.
+        bytes executionData;
+    }
+    // Send payload to all chains
+
+    struct MultiChainIntent {
+        address eoa;
+        Payload[] inputs; // [Base: 5 USDC, OP: 5 USDC] transfer to escrow
+        Payload output; // [Mainnet: 8 USDC] + Buy a sneaker + 2 USDC fees paid to the relay
+        Transfer[] fundTransfers;
+    }
 }

--- a/src/interfaces/ICommon.sol
+++ b/src/interfaces/ICommon.sol
@@ -92,20 +92,9 @@ interface ICommon {
         uint256 amount;
     }
 
-    struct Payload {
-        uint256 chainId;
-        uint256 nonce;
-        bytes[] encodedPreCalls;
-        /// @dev An encoded array of calls, using ERC7579 batch execution encoding.
-        /// `abi.encode(calls)`, where `calls` is of type `Call[]`.
-        /// This allows for more efficient safe forwarding to the EOA.
-        bytes executionData;
-    }
-
     struct MultiChainIntent {
-        address eoa;
-        bytes[] inputs;
-        bytes output;
-        bytes[] fundTransfers;
+        Intent[] inputs;
+        Intent output;
+        Transfer[] fundTransfers;
     }
 }

--- a/src/interfaces/ICommon.sol
+++ b/src/interfaces/ICommon.sol
@@ -95,17 +95,17 @@ interface ICommon {
     struct Payload {
         uint256 chainId;
         uint256 nonce;
+        bytes[] encodedPreCalls;
         /// @dev An encoded array of calls, using ERC7579 batch execution encoding.
         /// `abi.encode(calls)`, where `calls` is of type `Call[]`.
         /// This allows for more efficient safe forwarding to the EOA.
         bytes executionData;
     }
-    // Send payload to all chains
 
     struct MultiChainIntent {
         address eoa;
-        Payload[] inputs; // [Base: 5 USDC, OP: 5 USDC] transfer to escrow
-        Payload output; // [Mainnet: 8 USDC] + Buy a sneaker + 2 USDC fees paid to the relay
-        Transfer[] fundTransfers;
+        bytes[] inputs;
+        bytes output;
+        bytes[] fundTransfers;
     }
 }

--- a/src/interfaces/IIthacaAccount.sol
+++ b/src/interfaces/IIthacaAccount.sol
@@ -31,4 +31,7 @@ interface IIthacaAccount is ICommon {
     /// @dev Return the key hash that signed the latest execution context.
     /// @dev Returns bytes32(0) if the EOA key was used.
     function getContextKeyHash() external view returns (bytes32);
+
+    /// @dev Check and increment the nonce.
+    function checkAndIncrementNonce(uint256 nonce) external payable;
 }

--- a/test/utils/mocks/MockOrchestrator.sol
+++ b/test/utils/mocks/MockOrchestrator.sol
@@ -19,6 +19,10 @@ contract MockOrchestrator is Orchestrator, Brutalizer {
         return _computeDigest(intent);
     }
 
+    function computeDigest(MultiChainIntent calldata mIntent) public view returns (bytes32) {
+        return _computeDigest(mIntent);
+    }
+
     function simulateFailed(bytes calldata encodedIntent) public payable virtual {
         _execute(encodedIntent, type(uint256).max, 1);
         revert NoRevertEncountered();


### PR DESCRIPTION
This gives us pre call support + griefing protection + multi chain intent batching + other intent protections for interop flows.

To optimize calldata we can switch to merkle sigs in the next iteration.