### PR TITLE
feat: add CI workflow for automatic version bumping on bytecode changes

### DIFF
--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -3,6 +3,7 @@ name: Version Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  workflow_dispatch:
 
 jobs:
   check-bytecode-changes:

--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -1,0 +1,91 @@
+name: Version Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  check-bytecode-changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: nightly
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Build contracts on base branch
+        run: |
+          git checkout origin/${{ github.base_ref }}
+          forge build --force
+          mkdir -p /tmp/base-artifacts
+          cp -r out/* /tmp/base-artifacts/
+      
+      - name: Build contracts on PR branch
+        run: |
+          git checkout ${{ github.head_ref }}
+          forge build --force
+      
+      - name: Check bytecode changes and version
+        id: check
+        run: |
+          node scripts/check-bytecode-changes.js /tmp/base-artifacts out
+      
+      - name: Bump version if needed
+        if: steps.check.outputs.needs_version_bump == 'true'
+        run: |
+          # Configure git
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          
+          # Get current version
+          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          
+          # Bump patch version
+          IFS='.' read -r -a version_parts <<< "$CURRENT_VERSION"
+          PATCH=$((version_parts[2] + 1))
+          NEW_VERSION="${version_parts[0]}.${version_parts[1]}.$PATCH"
+          
+          echo "Bumping version from $CURRENT_VERSION to $NEW_VERSION"
+          
+          # Update package.json
+          npm version $NEW_VERSION --no-git-tag-version
+          
+          # Update Solidity files using the upgrade script
+          node prep/update-version.js
+          
+          # Commit changes
+          git add .
+          git commit -m "chore: bump version to $NEW_VERSION due to bytecode changes"
+          
+          # Push to the PR branch
+          git push origin HEAD:${{ github.head_ref }}
+      
+      - name: Create PR comment
+        if: steps.check.outputs.needs_version_bump == 'true'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '🤖 Bytecode changes detected! Version has been automatically bumped and EIP-712 domain versions have been updated.'
+            })

--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -46,7 +46,7 @@ jobs:
       - name: Check bytecode changes and version
         id: check
         run: |
-          node scripts/check-bytecode-changes.js /tmp/base-artifacts out
+          node prep/check-bytecode-changes.js /tmp/base-artifacts out
       
       - name: Bump version if needed
         if: steps.check.outputs.needs_version_bump == 'true'

--- a/prep/check-bytecode-changes.js
+++ b/prep/check-bytecode-changes.js
@@ -4,11 +4,12 @@ const fs = require("fs");
 const path = require("path");
 const crypto = require("crypto");
 
-// Main source contracts to check
+// Main contracts to check for bytecode changes
+// When any dependency (parent contracts, libraries, interfaces) changes,
+// it will be reflected in the bytecode of these contracts
 const CONTRACTS_TO_CHECK = [
   "IthacaAccount.sol/IthacaAccount.json",
   "Orchestrator.sol/Orchestrator.json",
-  "GuardedExecutor.sol/GuardedExecutor.json",
 ];
 
 function getBytecodeHash(artifactPath) {

--- a/scripts/check-bytecode-changes.js
+++ b/scripts/check-bytecode-changes.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const path = require("path");
+const crypto = require("crypto");
+
+// Main source contracts to check
+const CONTRACTS_TO_CHECK = [
+  "IthacaAccount.sol/IthacaAccount.json",
+  "Orchestrator.sol/Orchestrator.json",
+  "GuardedExecutor.sol/GuardedExecutor.json",
+];
+
+function getBytecodeHash(artifactPath) {
+  try {
+    const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+    const bytecode = artifact.bytecode?.object || "";
+
+    if (!bytecode || bytecode === "0x") {
+      console.warn(`Warning: No bytecode found in ${artifactPath}`);
+      return null;
+    }
+
+    // Remove metadata hash from bytecode (last 43 bytes for Solidity)
+    // This ensures we only compare actual code changes, not metadata
+    const cleanBytecode = bytecode.slice(0, -86); // 43 bytes = 86 hex chars
+
+    return crypto.createHash("sha256").update(cleanBytecode).digest("hex");
+  } catch (error) {
+    console.error(`Error reading artifact ${artifactPath}:`, error.message);
+    return null;
+  }
+}
+
+function compareArtifacts(baseDir, prDir) {
+  const changes = [];
+
+  for (const contract of CONTRACTS_TO_CHECK) {
+    const basePath = path.join(baseDir, contract);
+    const prPath = path.join(prDir, contract);
+
+    const baseHash = getBytecodeHash(basePath);
+    const prHash = getBytecodeHash(prPath);
+
+    if (baseHash && prHash && baseHash !== prHash) {
+      changes.push(contract);
+      console.log(`Bytecode changed: ${contract}`);
+    }
+  }
+
+  return changes;
+}
+
+function checkVersionBump() {
+  try {
+    // Check if package.json has been modified in this PR
+    const gitStatus = require("child_process")
+      .execSync("git diff --name-only origin/$GITHUB_BASE_REF...HEAD", {
+        encoding: "utf8",
+      })
+      .trim()
+      .split("\n");
+
+    return gitStatus.includes("package.json");
+  } catch (error) {
+    console.error("Error checking git status:", error.message);
+    return false;
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  if (args.length !== 2) {
+    console.error(
+      "Usage: check-bytecode-changes.js <base-artifacts-dir> <pr-artifacts-dir>"
+    );
+    process.exit(1);
+  }
+
+  const [baseDir, prDir] = args;
+
+  console.log("Checking bytecode changes...");
+  const changes = compareArtifacts(baseDir, prDir);
+
+  if (changes.length > 0) {
+    console.log(`\nFound bytecode changes in ${changes.length} contracts`);
+
+    const versionBumped = checkVersionBump();
+
+    if (!versionBumped) {
+      console.log("Version has not been bumped - automatic bump required");
+      // Use modern GitHub Actions output syntax
+      console.log(`::set-output name=needs_version_bump::true`);
+      fs.appendFileSync(
+        process.env.GITHUB_OUTPUT || "/dev/null",
+        "needs_version_bump=true\n"
+      );
+    } else {
+      console.log("Version has already been bumped");
+      console.log(`::set-output name=needs_version_bump::false`);
+      fs.appendFileSync(
+        process.env.GITHUB_OUTPUT || "/dev/null",
+        "needs_version_bump=false\n"
+      );
+    }
+  } else {
+    console.log("No bytecode changes detected");
+    console.log(`::set-output name=needs_version_bump::false`);
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT || "/dev/null",
+      "needs_version_bump=false\n"
+    );
+  }
+}
+
+if (require.main === module) {
+  main();
+}


### PR DESCRIPTION
Adds a GitHub Actions workflow that automatically bumps the version when bytecode changes are detected in IthacaAccount or Orchestrator contracts. This ensures the EIP-712 domain versions stay synchronized with contract updates.

The workflow monitors bytecode changes in IthacaAccount.sol and Orchestrator.sol. Since these contracts inherit from other contracts and use various libraries, any changes to their dependencies are automatically reflected in their bytecode. This makes the check comprehensive yet simple.

When bytecode changes are detected, the workflow automatically bumps the patch version in package.json and updates the version strings in both contracts using the existing prep/update-version.js script.

The implementation strips metadata from bytecode before comparison to avoid false positives from compiler metadata changes. The workflow is idempotent - it won't re-bump versions that have already been updated in a PR.

🤖 Generated with [Claude Code](https://claude.ai/code)