### PR TITLE
fix: don't send msg.value to settler

### DIFF
--- a/src/Orchestrator.sol
+++ b/src/Orchestrator.sol
@@ -461,8 +461,8 @@ contract Orchestrator is
             // If this is an output intent, then send the digest as the settlementId
             // on all input chains.
             if (i.encodedFundTransfers.length > 0) {
-                // Output intent - forward all msg.value to settler for multi-chain intents
-                ISettler(i.settler).send{value: msg.value}(digest, i.settlerContext);
+                // Output intent
+                ISettler(i.settler).send(digest, i.settlerContext);
             }
         } else {
             (isValid, keyHash) = _verify(digest, eoa, i.signature);


### PR DESCRIPTION
We have decided that relay will pay for settlement systems directly by calling something in the settler. 
Also the current version has a bug, as the msg.value is not sent to the self calls.