### PR TITLE
feat: allow withdrawals via owner signature

### DIFF
--- a/src/SimpleFunder.sol
+++ b/src/SimpleFunder.sol
@@ -25,7 +25,7 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
     error InvalidFunderSignature();
     error InvalidWithdrawalSignature();
     error InvalidNonce();
-    error Expired();
+    error DeadlineExpired();
 
     address public immutable ORCHESTRATOR;
 
@@ -83,7 +83,7 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
         }
 
         if (block.timestamp > deadline) {
-            revert Expired();
+            revert DeadlineExpired();
         }
 
         bytes32 digest = _hashTypedData(


### PR DESCRIPTION
Adds support for withdrawals via an EIP-712 signature from owner EOA. That way we're not forced to have direct access to owner private key to perform rebalances