### PR TITLE
fix: update version bump CI to match new requirements

### DIFF
--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -60,25 +60,19 @@ jobs:
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           
-          # Get current version
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
+          # Get the contracts that need bumping
+          CONTRACTS_TO_BUMP="${{ steps.check.outputs.contracts_to_bump }}"
           
-          # Bump patch version
-          IFS='.' read -r -a version_parts <<< "$CURRENT_VERSION"
-          PATCH=$((version_parts[2] + 1))
-          NEW_VERSION="${version_parts[0]}.${version_parts[1]}.$PATCH"
+          echo "Bumping versions for contracts: $CONTRACTS_TO_BUMP"
           
-          echo "Bumping version from $CURRENT_VERSION to $NEW_VERSION"
+          # Update Solidity files using the upgrade script with specific contracts
+          CONTRACTS_TO_BUMP="$CONTRACTS_TO_BUMP" node prep/update-version.js
           
-          # Update package.json
-          npm version $NEW_VERSION --no-git-tag-version
-          
-          # Update Solidity files using the upgrade script
-          node prep/update-version.js
-          
-          # Commit changes
-          git add .
-          git commit -m "chore: bump version to $NEW_VERSION due to bytecode changes"
+          # Commit changes (only Solidity files, not package.json)
+          git add src/*.sol
+          git commit -m "chore: bump contract versions due to bytecode changes
+
+Contracts updated: $CONTRACTS_TO_BUMP"
           
           # Push to the PR branch
           git push origin HEAD:${{ github.head_ref }}
@@ -88,9 +82,10 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
+            const contractsToBump = '${{ steps.check.outputs.contracts_to_bump }}';
             github.rest.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: '🤖 Bytecode changes detected! Version has been automatically bumped and EIP-712 domain versions have been updated.'
+              body: `🤖 Bytecode changes detected! EIP-712 domain versions have been automatically updated for: ${contractsToBump}`
             })


### PR DESCRIPTION
## Summary
- Removes package.json version bumping from CI
- Implements contract-specific version bump logic
- Updates CI workflow to only commit Solidity file changes

## Changes

### Version Bump Logic
- **IthacaAccount changes**: Only bump IthacaAccount version
- **Orchestrator changes**: Bump both Orchestrator and IthacaAccount versions (as Orchestrator changes affect Account)
- **SimpleFunder changes**: Only bump SimpleFunder version
- **Other peripheral contracts**: Only bump their own versions when their bytecode changes

### Technical Implementation
- Updated `check-bytecode-changes.js` to track which contracts need version bumps based on dependency rules
- Modified `update-version.js` to accept specific contracts to bump rather than bumping all
- Changed GitHub Actions workflow to:
  - Not update package.json
  - Only commit Solidity file changes
  - Pass specific contract list to the update script

Fixes #230

🤖 Generated with [Claude Code](https://claude.ai/code)