### PR TITLE
fix: add receive function to simpleFunder

### DIFF
--- a/src/SimpleFunder.sol
+++ b/src/SimpleFunder.sol
@@ -57,7 +57,7 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
         returns (string memory name, string memory version)
     {
         name = "SimpleFunder";
-        version = "0.1.0";
+        version = "0.1.1";
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -157,4 +157,6 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
 
         TokenTransferLib.safeTransfer(address(0), msg.sender, amount);
     }
+
+    receive() external payable {}
 }

--- a/test/SimpleFunder.t.sol
+++ b/test/SimpleFunder.t.sol
@@ -52,7 +52,7 @@ contract SimpleFunderTest is Test {
             abi.encode(
                 DOMAIN_TYPEHASH,
                 keccak256(bytes("SimpleFunder")),
-                keccak256(bytes("0.1.0")),
+                keccak256(bytes("0.1.1")),
                 block.chainid,
                 address(simpleFunder)
             )
@@ -62,6 +62,12 @@ contract SimpleFunderTest is Test {
             keccak256(abi.encode(WITHDRAWAL_TYPE_HASH, _token, _recipient, amount, deadline, nonce));
 
         return keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function test_receive() public {
+        (bool success,) = address(simpleFunder).call{value: 1 ether}("");
+        assertTrue(success);
+        assertEq(address(simpleFunder).balance, 11 ether);
     }
 
     function test_fund_withValidSignature() public {


### PR DESCRIPTION
This wasn't caught in tests, because we were using `vm.deal`