### PR TITLE
fix: resolve version bump CI push conflicts

### DIFF
--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -73,6 +73,9 @@ jobs:
           git add src/*.sol
           git commit -m "chore: bump contract versions due to bytecode changes - Contracts updated: $CONTRACTS_TO_BUMP"
           
+          # Pull latest changes and rebase
+          git pull origin ${{ github.event.pull_request.head.ref }} --rebase
+          
           # Push to the PR branch
           git push origin HEAD:${{ github.event.pull_request.head.ref }}
       

--- a/.github/workflows/version-check.yaml
+++ b/.github/workflows/version-check.yaml
@@ -74,7 +74,11 @@ jobs:
           git commit -m "chore: bump contract versions due to bytecode changes - Contracts updated: $CONTRACTS_TO_BUMP"
           
           # Pull latest changes and rebase
-          git pull origin ${{ github.event.pull_request.head.ref }} --rebase
+          # Pull latest changes and rebase
+          if ! git pull origin ${{ github.event.pull_request.head.ref }} --rebase; then
+            echo "Failed to rebase version bump changes. Manual intervention required."
+            exit 1
+          fi
           
           # Push to the PR branch
           git push origin HEAD:${{ github.event.pull_request.head.ref }}

--- a/src/IthacaAccount.sol
+++ b/src/IthacaAccount.sol
@@ -726,6 +726,6 @@ contract IthacaAccount is IIthacaAccount, EIP712, GuardedExecutor {
         returns (string memory name, string memory version)
     {
         name = "IthacaAccount";
-        version = "0.4.4";
+        version = "0.4.5";
     }
 }


### PR DESCRIPTION
The version bump CI job was failing with non-fast-forward errors when trying to push version updates. This happened when the PR branch had new commits pushed after the workflow started.

Added git pull --rebase before pushing to ensure the version bump commit is properly rebased on top of any new changes in the PR branch.

🤖 Generated with [Claude Code](https://claude.ai/code)