### PR TITLE
feat: add EIP-712 domain support to deployed contracts

### DIFF
--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -42,6 +42,34 @@ contract Escrow is IEscrow {
     /// @notice Thrown when the settler contract rejects the settlement
     error SettlementInvalid();
     ////////////////////////////////////////////////////////////////////////
+    // EIP-5267 Support
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev See: https://eips.ethereum.org/EIPS/eip-5267
+    /// Returns the fields and values that describe the domain separator used for signing.
+    function eip712Domain()
+        public
+        view
+        returns (
+            bytes1 fields,
+            string memory name,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        )
+    {
+        fields = hex"0f"; // `0b01111` - has name, version, chainId, verifyingContract
+        name = "Escrow";
+        version = "0.4.4";
+        chainId = block.chainid;
+        verifyingContract = address(this);
+        salt = bytes32(0);
+        extensions = new uint256[](0);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
     // State Variables
     ////////////////////////////////////////////////////////////////////////
 

--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -47,6 +47,8 @@ contract Escrow is IEscrow {
 
     /// @dev See: https://eips.ethereum.org/EIPS/eip-5267
     /// Returns the fields and values that describe the domain separator used for signing.
+    /// Note: This is just for labelling and offchain verification purposes.
+    /// This contract does not use EIP712 signatures anywhere else.
     function eip712Domain()
         public
         view

--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -62,7 +62,7 @@ contract Escrow is IEscrow {
     {
         fields = hex"0f"; // `0b01111` - has name, version, chainId, verifyingContract
         name = "Escrow";
-        version = "0.4.4";
+        version = "0.0.1";
         chainId = block.chainid;
         verifyingContract = address(this);
         salt = bytes32(0);

--- a/src/LayerZeroSettler.sol
+++ b/src/LayerZeroSettler.sol
@@ -43,7 +43,7 @@ contract LayerZeroSettler is OApp, ISettler {
     {
         fields = hex"0f"; // `0b01111` - has name, version, chainId, verifyingContract
         name = "LayerZeroSettler";
-        version = "0.4.4";
+        version = "0.0.1";
         chainId = block.chainid;
         verifyingContract = address(this);
         salt = bytes32(0);

--- a/src/LayerZeroSettler.sol
+++ b/src/LayerZeroSettler.sol
@@ -22,6 +22,34 @@ contract LayerZeroSettler is OApp, ISettler {
 
     constructor(address _endpoint, address _owner) OApp(_endpoint, _owner) Ownable(_owner) {}
 
+    ////////////////////////////////////////////////////////////////////////
+    // EIP-5267 Support
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev See: https://eips.ethereum.org/EIPS/eip-5267
+    /// Returns the fields and values that describe the domain separator used for signing.
+    function eip712Domain()
+        public
+        view
+        returns (
+            bytes1 fields,
+            string memory name,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        )
+    {
+        fields = hex"0f"; // `0b01111` - has name, version, chainId, verifyingContract
+        name = "LayerZeroSettler";
+        version = "0.4.4";
+        chainId = block.chainid;
+        verifyingContract = address(this);
+        salt = bytes32(0);
+        extensions = new uint256[](0);
+    }
+
     /// @notice Mark the settlement as valid to be sent
     function send(bytes32 settlementId, bytes calldata settlerContext) external payable override {
         validSend[keccak256(abi.encode(msg.sender, settlementId, settlerContext))] = true;

--- a/src/LayerZeroSettler.sol
+++ b/src/LayerZeroSettler.sol
@@ -28,6 +28,8 @@ contract LayerZeroSettler is OApp, ISettler {
 
     /// @dev See: https://eips.ethereum.org/EIPS/eip-5267
     /// Returns the fields and values that describe the domain separator used for signing.
+    /// Note: This is just for labelling and offchain verification purposes.
+    /// This contract does not use EIP712 signatures anywhere else.
     function eip712Domain()
         public
         view

--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -137,6 +137,34 @@ contract MultiSigSigner is ISigner {
     }
 
     ////////////////////////////////////////////////////////////////////////
+    // EIP-5267 Support
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev See: https://eips.ethereum.org/EIPS/eip-5267
+    /// Returns the fields and values that describe the domain separator used for signing.
+    function eip712Domain()
+        public
+        view
+        returns (
+            bytes1 fields,
+            string memory name,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        )
+    {
+        fields = hex"0f"; // `0b01111` - has name, version, chainId, verifyingContract
+        name = "MultiSigSigner";
+        version = "0.4.4";
+        chainId = block.chainid;
+        verifyingContract = address(this);
+        salt = bytes32(0);
+        extensions = new uint256[](0);
+    }
+
+    ////////////////////////////////////////////////////////////////////////
     // Signature Validation
     ////////////////////////////////////////////////////////////////////////
 

--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -157,7 +157,7 @@ contract MultiSigSigner is ISigner {
     {
         fields = hex"0f"; // `0b01111` - has name, version, chainId, verifyingContract
         name = "MultiSigSigner";
-        version = "0.4.4";
+        version = "0.0.1";
         chainId = block.chainid;
         verifyingContract = address(this);
         salt = bytes32(0);

--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -142,6 +142,8 @@ contract MultiSigSigner is ISigner {
 
     /// @dev See: https://eips.ethereum.org/EIPS/eip-5267
     /// Returns the fields and values that describe the domain separator used for signing.
+    /// Note: This is just for labelling and offchain verification purposes.
+    /// This contract does not use EIP712 signatures anywhere else.
     function eip712Domain()
         public
         view

--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -7,7 +7,35 @@ import {FixedPointMathLib as Math} from "solady/utils/FixedPointMathLib.sol";
 /// @title Simulator
 /// @notice A separate contract for calling the Orchestrator contract solely for gas simulation.
 contract Simulator {
+    ////////////////////////////////////////////////////////////////////////
+    // EIP-5267 Support
+    ////////////////////////////////////////////////////////////////////////
+
+    /// @dev See: https://eips.ethereum.org/EIPS/eip-5267
+    /// Returns the fields and values that describe the domain separator used for signing.
+    function eip712Domain()
+        public
+        view
+        returns (
+            bytes1 fields,
+            string memory name,
+            string memory version,
+            uint256 chainId,
+            address verifyingContract,
+            bytes32 salt,
+            uint256[] memory extensions
+        )
+    {
+        fields = hex"0f"; // `0b01111` - has name, version, chainId, verifyingContract
+        name = "Simulator";
+        version = "0.4.4";
+        chainId = block.chainid;
+        verifyingContract = address(this);
+        salt = bytes32(0);
+        extensions = new uint256[](0);
+    }
     /// @dev This modifier is used to free up memory after a function call.
+
     modifier freeTempMemory() {
         uint256 m;
         assembly ("memory-safe") {

--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -28,7 +28,7 @@ contract Simulator {
     {
         fields = hex"0f"; // `0b01111` - has name, version, chainId, verifyingContract
         name = "Simulator";
-        version = "0.4.4";
+        version = "0.0.1";
         chainId = block.chainid;
         verifyingContract = address(this);
         salt = bytes32(0);

--- a/src/Simulator.sol
+++ b/src/Simulator.sol
@@ -13,6 +13,8 @@ contract Simulator {
 
     /// @dev See: https://eips.ethereum.org/EIPS/eip-5267
     /// Returns the fields and values that describe the domain separator used for signing.
+    /// Note: This is just for labelling and offchain verification purposes.
+    /// This contract does not use EIP712 signatures anywhere else.
     function eip712Domain()
         public
         view


### PR DESCRIPTION
Fixes issue #262 
## Summary
- Added `eip712Domain()` function to all independently deployed contracts that don't already inherit it from Solady's EIP712 library
- This provides EIP-5267 compliant domain separator information for each contract

## Changes
Added `eip712Domain()` function to:
- `MultiSigSigner.sol` - Returns domain info for multi-sig signer contract
- `Simulator.sol` - Returns domain info for gas simulation contract  
- `LayerZeroSettler.sol` - Returns domain info for cross-chain settler
- `Escrow.sol` - Returns domain info for escrow contract

Each function returns:
- `fields`: `0x0f` (indicating name, version, chainId, and verifyingContract are present)
- `name`: Contract-specific name
- `version`: "0.4.4" (matching package.json version)
- `chainId`: Current chain ID via `block.chainid`
- `verifyingContract`: The contract's own address
- `salt`: Empty bytes32
- `extensions`: Empty uint256 array

## Notes
The following contracts were NOT modified as they already have EIP-712 support:
- `Orchestrator.sol` - Already inherits from EIP712
- `SimpleFunder.sol` - Already inherits from EIP712  
- `SimpleSettler.sol` - Already inherits from EIP712
- `IthacaAccount.sol` - Already inherits from EIP712
- `PauseAuthority.sol` - Abstract contract, not deployed independently
- `GuardedExecutor.sol` - Abstract contract, not deployed independently

## Testing
All tests pass except for one unrelated deployment test that tries to connect to an RPC endpoint that's currently down.

🤖 Generated with [Claude Code](https://claude.ai/code)