### PR TITLE
fix: add threshold safety check in multisigsigner

### DIFF
--- a/src/MultiSigSigner.sol
+++ b/src/MultiSigSigner.sol
@@ -75,8 +75,8 @@ contract MultiSigSigner is ISigner {
     function initConfig(bytes32 keyHash, uint256 threshold, bytes32[] memory ownerKeyHashes)
         public
     {
-        // Threshold can't be zero
-        if (threshold == 0) revert InvalidThreshold();
+        // Threshold can't be zero or less than the number of owners
+        if (threshold == 0 || threshold < ownerKeyHashes.length) revert InvalidThreshold();
 
         Config storage config = _configs[msg.sender][keyHash];
 


### PR DESCRIPTION
Small fix to add a threshold safety check. This prevents setting impossible verification rules like a higher threshold than the number of owners which would brick an account at the expense of some gas