### PR TITLE
refactor: configure Claude CI/CD for label-triggered PR reviews

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -69,6 +69,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: true
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
 
       - name: Run Claude Code Action
         uses: anthropics/claude-code-action@beta
@@ -79,7 +85,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           timeout_minutes: "60"
           disallowed_tools: "npm,yarn"
-          allowed_tools: "mcp__github__create_pull_request,Bash(pnpm check),Bash(pnpm check:*),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm install),Bash(pnpm build)"
+          allowed_tools: "mcp__github__create_pull_request,Bash(forge build),Bash(forge test),Bash(forge test *),Bash(forge fmt),Bash(forge snapshot)"
           custom_instructions: |
             You MUST follow the development workflow described in CLAUDE.md.
             You MUST open a draft pull request after creating a branch.

--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -69,9 +69,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          
-      - name: Install dependencies
-        uses: ./.github/actions/install-dependencies
 
       - name: Run Claude Code Action
         uses: anthropics/claude-code-action@beta

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -2,7 +2,7 @@ name: Claude Review
 
 on:
   pull_request:
-    types: [opened, ready_for_review, labeled]
+    types: [labeled]
 
 env:
   ACTIONS_RUNNER_DEBUG: true
@@ -27,36 +27,17 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // Check if this is a PR-related event and not authored by Claude
-            const isNotClaude = context.payload.pull_request?.user?.login !== 'claude-bot' && 
-                                context.payload.issue?.user?.login !== 'claude-bot';
-            
-            // Check if this is a labeled event with the 'claude-review' label
-            const isClaudeReviewLabel = context.eventName === 'pull_request' && 
-                                       context.payload.action === 'labeled' && 
-                                       context.payload.label?.name === 'claude-review';
-            
-            // Check if PR is not a draft (for opened/ready_for_review events)
-            const isNotDraft = !context.payload.pull_request?.draft;
+            // Check if the 'claude-review' label was added
+            const isClaudeReviewLabel = context.payload.label?.name === 'claude-review';
             
             // Check if PR body contains the skip marker
             const prBody = context.payload.pull_request?.body || '';
             const hasSkipMarker = prBody.includes('<!-- claude_skip -->');
             
-            // Should review if:
-            // 1. Claude review label was added, OR
-            // 2. PR was opened/ready_for_review and is not a draft
-            // AND PR body doesn't contain the skip marker
-            const shouldReview = isNotClaude && !hasSkipMarker && (isClaudeReviewLabel || 
-                                (context.payload.action !== 'labeled' && isNotDraft));
+            // Should review if claude-review label was added and PR doesn't have skip marker
+            const shouldReview = isClaudeReviewLabel && !hasSkipMarker;
             
-            console.log(`Event: ${context.eventName}, Action: ${context.payload.action}`);
             console.log(`Label name: "${context.payload.label?.name}"`);
-            console.log(`Checking conditions:`);
-            console.log(`  eventName === 'pull_request': ${context.eventName === 'pull_request'}`);
-            console.log(`  action === 'labeled': ${context.payload.action === 'labeled'}`);
-            console.log(`  label name === 'claude-review': ${context.payload.label?.name === 'claude-review'}`);
-            console.log(`Is not Claude: ${isNotClaude}, Is claude-review label: ${isClaudeReviewLabel}, Is not draft: ${isNotDraft}`);
             console.log(`Has skip marker: ${hasSkipMarker}`);
             console.log(`Should review: ${shouldReview}`);
             

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -21,6 +21,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: true
+
+      - name: Install Foundry
+        uses: foundry-rs/foundry-toolchain@v1
+        with:
+          version: stable
 
       - name: Check
         id: check_pr_review
@@ -52,7 +58,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           timeout_minutes: "60"
           disallowed_tools: "npm,yarn"
-          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(pnpm check),Bash(pnpm check:*),Bash(pnpm test),Bash(pnpm test:*),Bash(pnpm install),Bash(pnpm build)"
+          allowed_tools: "mcp__github__create_pull_request,mcp__github__create_pending_pull_request_review,mcp__github__get_pull_request_diff,mcp__github__add_pull_request_review_comment_to_pending_review,mcp__github__submit_pending_pull_request_review,Bash(forge build),Bash(forge test),Bash(forge test *),Bash(forge fmt),Bash(forge snapshot)"
           direct_prompt: |-
             Please review this PR and provide inline feedback using the GitHub review system. Follow these steps:
 


### PR DESCRIPTION
Modified the Claude PR review workflow to only trigger when the 'claude-review' label is added to a PR, rather than running automatically on every PR opened or marked ready for review. (This was spamming our open PRs)

This gives maintainers more control over when Claude reviews are performed and reduces unnecessary workflow runs.

The @claude mention functionality in issues and PR comments was already implemented in the claude-code.yml workflow, but wasn't working for some reason. We will only be able to test it, once this gets merged to main.