### PR TITLE
refactor(LibTStack): declare EmptyStack error for proper revert decoding

### DIFF
--- a/src/libraries/LibTStack.sol
+++ b/src/libraries/LibTStack.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.23;
 
+error EmptyStack();
+
 /// @notice A minimal bytes32 stack implementation in transient storage.
 library LibTStack {
     /// @dev Helper struct to store the base slot of the stack.


### PR DESCRIPTION
Declare error EmptyStack(); at file scope in src/libraries/LibTStack.sol
Keeps existing assembly reverts (selector 0xbc7ec779) — no behavior change
Improves readability and enables tooling/decoders to resolve the revert
Affects top and pop paths only