### PR TITLE
chore: fix solidity version to 0.8.28

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,6 +9,7 @@
 extends = "deploy/config.toml"
 evm_version = "prague" # Cancun will be tested in the CI.
 auto_detect_solc = false
+solc_version = "0.8.28"
 optimizer = true
 optimizer_runs = 200
 gas_limit = 100_000_000 # ETH is 30M, but we use a higher value.


### PR DESCRIPTION
Without this, create2 addresses could be accidentally deployed with different solidity version.