### PR TITLE
feat: remove chainid from 1271 signatures

### DIFF
--- a/src/IthacaAccount.sol
+++ b/src/IthacaAccount.sol
@@ -241,7 +241,7 @@ contract IthacaAccount is IIthacaAccount, EIP712, GuardedExecutor {
         // The account domain is added as a layer to prevent replay attacks since some apps do not include the
         // account address as a field in their 712 data.
         bytes32 replaySafeDigest = EfficientHashLib.hash(SIGN_TYPEHASH, digest);
-        digest = _hashTypedData(replaySafeDigest);
+        digest = _hashTypedDataSansChainId(replaySafeDigest);
 
         (bool isValid, bytes32 keyHash) = unwrapAndValidateSignature(digest, signature);
         if (LibBit.and(keyHash != 0, isValid)) {

--- a/test/Account.t.sol
+++ b/test/Account.t.sol
@@ -97,10 +97,9 @@ contract AccountTest is BaseTest {
         = d.d.eip712Domain();
         bytes32 domain = keccak256(
             abi.encode(
-                0x8b73c3c69bb8fe3d512ecc4cf759cc79239f7b179b0ffacaa9a75d522b39400f, // DOMAIN_TYPEHASH,
+                0x91ab3d17e3a50a9d89e63fd30b92be7f5336b03b287bb946787a83a9d62a2766, // DOMAIN_TYPEHASH without chainid,
                 keccak256(abi.encodePacked(name)),
                 keccak256(abi.encodePacked(version)),
-                chainId,
                 verifyingContract
             )
         );


### PR DESCRIPTION
this allows offchain messages like SIWE to be replayable across chains

we now rely on apps to provide chain level replay protection but this should be a reasonable ask