### PR TITLE
feat: add ExpToken deployment to DeployMain script

### DIFF
--- a/deploy/DeployMain.s.sol
+++ b/deploy/DeployMain.s.sol
@@ -15,6 +15,7 @@ import {SimpleFunder} from "../src/SimpleFunder.sol";
 import {Escrow} from "../src/Escrow.sol";
 import {SimpleSettler} from "../src/SimpleSettler.sol";
 import {LayerZeroSettler} from "../src/LayerZeroSettler.sol";
+import {ExperimentERC20} from "./mock/ExperimentalERC20.sol";
 
 /**
  * @title DeployMain
@@ -66,6 +67,9 @@ contract DeployMain is Script, SafeSingletonDeployer {
         uint32 layerZeroEid;
         bytes32 salt;
         string[] contracts; // Array of contract names to deploy
+        // EXP Token configuration (testnet only)
+        address expMinterAddress;
+        uint256 expMintAmount;
     }
 
     struct DeployedContracts {
@@ -77,6 +81,8 @@ contract DeployMain is Script, SafeSingletonDeployer {
         address layerZeroSettler;
         address simpleFunder;
         address simulator;
+        address expToken; // EXP token (testnet only)
+        address exp2Token; // EXP2 token (testnet only)
     }
 
     // State
@@ -223,6 +229,12 @@ contract DeployMain is Script, SafeSingletonDeployer {
         config.layerZeroEid = uint32(vm.readForkUint("layerzero_eid"));
         config.salt = vm.readForkBytes32("salt");
 
+        // Load EXP token configuration (testnet only)
+        if (config.isTestnet) {
+            config.expMinterAddress = vm.readForkAddress("exp_minter_address");
+            config.expMintAmount = vm.readForkUint("exp_mint_amount");
+        }
+
         // Load contracts list - required field, will revert if not present
         string[] memory contractsList = vm.readForkStringArray("contracts");
 
@@ -231,7 +243,19 @@ contract DeployMain is Script, SafeSingletonDeployer {
             contractsList.length == 1
                 && keccak256(bytes(contractsList[0])) == keccak256(bytes("ALL"))
         ) {
-            config.contracts = getAllContracts();
+            string[] memory baseContracts = getAllContracts();
+            // For testnets with ALL specified, append ExpToken
+            if (config.isTestnet) {
+                string[] memory testnetContracts = new string[](baseContracts.length + 1);
+                for (uint256 i = 0; i < baseContracts.length; i++) {
+                    testnetContracts[i] = baseContracts[i];
+                }
+                testnetContracts[baseContracts.length] = "ExpToken";
+                config.contracts = testnetContracts;
+            } else {
+                // For non-testnets, use base contracts (no ExpToken)
+                config.contracts = baseContracts;
+            }
         } else {
             config.contracts = contractsList;
         }
@@ -240,7 +264,7 @@ contract DeployMain is Script, SafeSingletonDeployer {
     }
 
     /**
-     * @notice Get all available contracts
+     * @notice Get all available contracts (excluding ExpToken)
      */
     function getAllContracts() internal pure returns (string[] memory) {
         string[] memory contracts = new string[](8);
@@ -292,6 +316,8 @@ contract DeployMain is Script, SafeSingletonDeployer {
                 deployed.layerZeroSettler = tryReadAddress(registryJson, ".LayerZeroSettler");
                 deployed.simpleFunder = tryReadAddress(registryJson, ".SimpleFunder");
                 deployed.simulator = tryReadAddress(registryJson, ".Simulator");
+                deployed.expToken = tryReadAddress(registryJson, ".ExpToken");
+                deployed.exp2Token = tryReadAddress(registryJson, ".Exp2Token");
 
                 deployedContracts[chainId] = deployed;
             } catch {
@@ -447,6 +473,10 @@ contract DeployMain is Script, SafeSingletonDeployer {
             deployedContracts[chainId].simpleSettler = contractAddress;
         } else if (keccak256(bytes(contractName)) == keccak256("LayerZeroSettler")) {
             deployedContracts[chainId].layerZeroSettler = contractAddress;
+        } else if (keccak256(bytes(contractName)) == keccak256("ExpToken")) {
+            deployedContracts[chainId].expToken = contractAddress;
+        } else if (keccak256(bytes(contractName)) == keccak256("Exp2Token")) {
+            deployedContracts[chainId].exp2Token = contractAddress;
         }
 
         // Write to registry file
@@ -520,6 +550,18 @@ contract DeployMain is Script, SafeSingletonDeployer {
             json = string.concat(
                 json, '"LayerZeroSettler": "', vm.toString(deployed.layerZeroSettler), '"'
             );
+            first = false;
+        }
+
+        if (deployed.expToken != address(0)) {
+            if (!first) json = string.concat(json, ",");
+            json = string.concat(json, '"ExpToken": "', vm.toString(deployed.expToken), '"');
+            first = false;
+        }
+
+        if (deployed.exp2Token != address(0)) {
+            if (!first) json = string.concat(json, ",");
+            json = string.concat(json, '"Exp2Token": "', vm.toString(deployed.exp2Token), '"');
         }
 
         json = string.concat(json, "}");
@@ -663,6 +705,8 @@ contract DeployMain is Script, SafeSingletonDeployer {
             deploySimpleSettler(chainId, config, deployed);
         } else if (nameHash == keccak256("LayerZeroSettler")) {
             deployLayerZeroSettler(chainId, config, deployed);
+        } else if (nameHash == keccak256("ExpToken")) {
+            deployExpToken(chainId, config, deployed);
         } else {
             console.log("Warning: Unknown contract name:", contractName);
         }
@@ -826,6 +870,56 @@ contract DeployMain is Script, SafeSingletonDeployer {
             deployed.layerZeroSettler = settler;
         } else {
             console.log("LayerZeroSettler already deployed:", deployed.layerZeroSettler);
+        }
+    }
+
+    function deployExpToken(
+        uint256 chainId,
+        ChainConfig memory config,
+        DeployedContracts memory deployed
+    ) internal {
+        // Only deploy on testnets
+        if (!config.isTestnet) {
+            console.log("Skipping ExpToken deployment - not a testnet");
+            return;
+        }
+
+        bytes memory creationCode = type(ExperimentERC20).creationCode;
+
+        // Deploy EXP token
+        if (deployed.expToken == address(0)) {
+            // Hardcode name and symbol to "EXP"
+            bytes memory args = abi.encode("EXP", "EXP", 1 ether);
+            address expToken = deployContractWithCreate2(chainId, creationCode, args, "ExpToken");
+
+            // Mint initial tokens to the configured minter address
+            ExperimentERC20(payable(expToken)).mint(config.expMinterAddress, config.expMintAmount);
+
+            console.log("  EXP Name/Symbol: EXP");
+            console.log("  EXP Address:", expToken);
+            saveDeployedContract(chainId, "ExpToken", expToken);
+            deployed.expToken = expToken;
+        } else {
+            console.log("ExpToken already deployed:", deployed.expToken);
+        }
+
+        // Deploy EXP2 token
+        if (deployed.exp2Token == address(0)) {
+            // Hardcode name and symbol to "EXP2"
+            bytes memory args2 = abi.encode("EXP2", "EXP2", 1 ether);
+            address exp2Token = deployContractWithCreate2(chainId, creationCode, args2, "Exp2Token");
+
+            // Mint initial tokens to the configured minter address (same as EXP)
+            ExperimentERC20(payable(exp2Token)).mint(config.expMinterAddress, config.expMintAmount);
+
+            console.log("  EXP2 Name/Symbol: EXP2");
+            console.log("  EXP2 Address:", exp2Token);
+            console.log("  Minter:", config.expMinterAddress);
+            console.log("  Mint Amount (each):", config.expMintAmount);
+            saveDeployedContract(chainId, "Exp2Token", exp2Token);
+            deployed.exp2Token = exp2Token;
+        } else {
+            console.log("Exp2Token already deployed:", deployed.exp2Token);
         }
     }
 }

--- a/deploy/config.toml
+++ b/deploy/config.toml
@@ -49,6 +49,9 @@ layerzero_max_message_size = 10000
 # DVN addresses
 dvn_layerzero_labs = "0x8eebf8b423B73bFCa51a1Db4B7354AA0bFCA9193"
 dvn_google_cloud = "0x8e5a7b5959C5A7C732b87dCE401E07F5819eEC2d"
+# EXP Token configuration (testnet only)
+exp_minter_address = "0x0000000000000000000000000000000000000003"
+exp_mint_amount = "1000000000000000000000"  # 1000 tokens
 
 # Base Sepolia
 [forks.base-sepolia]
@@ -89,6 +92,9 @@ layerzero_max_message_size = 10000
 # DVN addresses
 dvn_layerzero_labs = "0xe1a12515F9AB2764b887bF60B923Ca494EBbB2d6"
 dvn_google_cloud = "0xFc9d8E5d3FaB22fB6E93E9E2C90916E9dCa83Ade"
+# EXP Token configuration (testnet only)
+exp_minter_address = "0xB6918DaaB07e31556B45d7Fd2a33021Bc829adf4"
+exp_mint_amount = "5000000000000000000000"  # 5000 tokens
 
 # Optimism Sepolia
 [forks.optimism-sepolia]
@@ -126,6 +132,9 @@ layerzero_max_message_size = 10000
 # DVN addresses
 dvn_layerzero_labs = "0x28B6140ead70cb2Fb669705b3598ffB4BEaA060b"
 dvn_google_cloud = "0x28b8B8Ea5C695EFa657B6b86a4a8E90ccbA93E9e"
+# EXP Token configuration (testnet only)
+exp_minter_address = "0xB6918DaaB07e31556B45d7Fd2a33021Bc829adf4"
+exp_mint_amount = "2000000000000000000000"  # 2000 tokens
 
 
 


### PR DESCRIPTION
## Summary

Cherry-picked commit that adds ExpToken (EXP and EXP2) deployment functionality to the DeployMain script for testnet chains.

## Changes

### DeployMain Script
- Added ExpToken deployment function that creates two tokens: "EXP" and "EXP2"
- Testnet-only deployment logic - ExpToken only deploys when `is_testnet = true`
- Integration with "ALL" contracts filter - ExpToken automatically included for testnets
- Required configuration fields: `exp_minter_address` and `exp_mint_amount`
- Both tokens mint to the same address with the same amount
- CREATE2 deployment for deterministic addresses
- Registry tracking for both token addresses

### Configuration
- Added EXP token configuration to all testnet chains in config.toml
- Required fields with no defaults - deployment fails if missing on testnets

### Documentation
- Updated deploy/README.md with comprehensive ExpToken documentation
- Removed old DeployEXP script references
- Added configuration examples and behavior explanation
- Registry file format documentation

## Testing

Verified deployment behavior:
- ✅ Testnets (`is_testnet = true`): Deploys 8 core contracts + ExpToken (9 total)
- ✅ Production (`is_testnet = false`): Deploys 8 core contracts only
- ✅ Both EXP and EXP2 tokens deployed with correct names and addresses
- ✅ Required configuration enforced - fails with clear error if missing