### PR TITLE
feat: allow early refunds by recipient in escrow

### DIFF
--- a/src/Escrow.sol
+++ b/src/Escrow.sol
@@ -131,12 +131,12 @@ contract Escrow is IEscrow {
         for (uint256 i = 0; i < escrowIds.length; i++) {
             Escrow storage _escrow = escrows[escrowIds[i]];
             // If refund timestamp hasn't passed yet, then the refund is invalid.
-            if (block.timestamp <= _escrow.refundTimestamp) {
+            if (block.timestamp > _escrow.refundTimestamp || msg.sender == _escrow.recipient) {
+                _refundDepositor(escrowIds[i], _escrow);
+                _refundRecipient(escrowIds[i], _escrow);
+            } else {
                 revert RefundInvalid();
             }
-
-            _refundDepositor(escrowIds[i], _escrow);
-            _refundRecipient(escrowIds[i], _escrow);
         }
     }
 
@@ -146,10 +146,11 @@ contract Escrow is IEscrow {
         for (uint256 i = 0; i < escrowIds.length; i++) {
             Escrow storage _escrow = escrows[escrowIds[i]];
             // If refund timestamp hasn't passed yet, then the refund is invalid.
-            if (block.timestamp <= _escrow.refundTimestamp) {
+            if (block.timestamp > _escrow.refundTimestamp || msg.sender == _escrow.depositor) {
+                _refundDepositor(escrowIds[i], _escrow);
+            } else {
                 revert RefundInvalid();
             }
-            _refundDepositor(escrowIds[i], _escrow);
         }
     }
 
@@ -180,11 +181,11 @@ contract Escrow is IEscrow {
             Escrow storage _escrow = escrows[escrowIds[i]];
 
             // If settlement is still within the deadline, then refund is invalid.
-            if (block.timestamp <= _escrow.refundTimestamp) {
+            if (block.timestamp > _escrow.refundTimestamp || msg.sender == _escrow.recipient) {
+                _refundRecipient(escrowIds[i], _escrow);
+            } else {
                 revert RefundInvalid();
             }
-
-            _refundRecipient(escrowIds[i], _escrow);
         }
     }
 


### PR DESCRIPTION
This allows the relay to refund the user early, if they know that the intent cannot be executed on the destination chain.

WARNING: It is important for the recipient to make sure that the intent has expired on the destination chain, before executing early refunds. 
Otherwise there could be cases where the intent becomes valid after sometime, and someone replays their funder signature, to give the user funds.

Destination chain intent expiry should always be smaller than the refund time.