### PR TITLE
feat: allow funders to support older ocs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # porto-account
 
+## 0.5.4
+
+### Patch Changes
+
+- SimpleFunder supports multiple orchestrators instead of single immutable orchestrator
+  - Replaced immutable `ORCHESTRATOR` with `orchestrators` mapping and `setOrchestrators()` function
+  - Maintained backward compatibility with old `fund()` signature
+  - Added `supported_orchestrators` config field for deployment
+  - Version bumped to "0.1.5"
+
 ## 0.5.0
 
 ### Minor Changes

--- a/deploy/DeployMain.s.sol
+++ b/deploy/DeployMain.s.sol
@@ -798,21 +798,10 @@ contract DeployMain is Script, SafeSingletonDeployer {
         ChainConfig memory config,
         DeployedContracts memory deployed
     ) internal {
-        // Ensure Orchestrator is deployed first (dependency)
-        if (deployed.orchestrator == address(0)) {
-            console.log("Deploying Orchestrator first (dependency for SimpleFunder)...");
-            deployOrchestrator(chainId, config, deployed);
-        }
-
         if (deployed.simpleFunder == address(0)) {
             bytes memory creationCode = type(SimpleFunder).creationCode;
-            address[] memory newOrchestrators = new address[](config.orchestrators.length + 1);
-            for (uint256 i; i < config.orchestrators.length; i++) {
-                newOrchestrators[i] = config.orchestrators[i];
-            }
-            newOrchestrators[config.orchestrators.length] = deployed.orchestrator;
-            bytes memory args =
-                abi.encode(config.funderSigner, newOrchestrators, config.funderOwner);
+
+            bytes memory args = abi.encode(config.funderSigner, config.funderOwner);
             address funder = deployContractWithCreate2(chainId, creationCode, args, "SimpleFunder");
 
             saveDeployedContract(chainId, "SimpleFunder", funder);

--- a/deploy/DeployMain.s.sol
+++ b/deploy/DeployMain.s.sol
@@ -64,6 +64,7 @@ contract DeployMain is Script, SafeSingletonDeployer {
         address l0SettlerOwner;
         address l0SettlerSigner;
         address layerZeroEndpoint;
+        address[] oldOrchestrators;
         uint32 layerZeroEid;
         bytes32 salt;
         string[] contracts; // Array of contract names to deploy
@@ -805,8 +806,13 @@ contract DeployMain is Script, SafeSingletonDeployer {
 
         if (deployed.simpleFunder == address(0)) {
             bytes memory creationCode = type(SimpleFunder).creationCode;
+            address[] memory newOrchestrators = new address[](config.orchestrators.length + 1);
+            for (uint256 i; i < config.orchestrators.length; i++) {
+                newOrchestrators[i] = config.orchestrators[i];
+            }
+            newOrchestrators[config.orchestrators.length] = deployed.orchestrator;
             bytes memory args =
-                abi.encode(config.funderSigner, deployed.orchestrator, config.funderOwner);
+                abi.encode(config.funderSigner, newOrchestrators, config.funderOwner);
             address funder = deployContractWithCreate2(chainId, creationCode, args, "SimpleFunder");
 
             saveDeployedContract(chainId, "SimpleFunder", funder);

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -85,6 +85,7 @@ contracts = ["ALL"]               # Or specific: ["Orchestrator", "IthacaAccount
 target_balance = 1000000000000000 # Target balance per signer (0.001 ETH)
 simple_funder_address = "0x..."   # SimpleFunder address
 default_num_signers = 10          # Number of signers to fund
+supported_orchestrators = ["0x..."] # Orchestrator addresses to enable in SimpleFunder
 
 # LayerZero configuration (only needed for ConfigureLayerZero)
 layerzero_settler_address = "0x..."
@@ -244,6 +245,7 @@ forge script deploy/ConfigureLayerZeroSettler.s.sol:ConfigureLayerZeroSettler \
 1. Derives signer addresses from mnemonic
 2. Tops up signers below target_balance
 3. Registers signers as gas wallets in SimpleFunder
+4. Sets configured orchestrators in SimpleFunder
 
 ```bash
 # Fund default number of signers (from config)
@@ -397,6 +399,7 @@ forge script deploy/DeployMain.s.sol:DeployMain \
 | `target_balance` | FundSigners | Minimum signer balance |
 | `simple_funder_address` | FundSigners, FundSimpleFunder | SimpleFunder location |
 | `default_num_signers` | FundSigners | Number of signers |
+| `supported_orchestrators` | FundSigners | Orchestrator addresses to enable in SimpleFunder |
 | `layerzero_*` fields | ConfigureLayerZeroSettler | LayerZero configuration |
 | `exp_minter_address`, `exp_mint_amount` | DeployMain (testnet) | ExpToken deployment |
 

--- a/deploy/config.toml
+++ b/deploy/config.toml
@@ -35,6 +35,7 @@ contracts = ["LayerZeroSettler"]
 # SimpleFunder configuration
 simple_funder_address = "0x2AD8F6a3bB1126a777606eaFa9da9b95530d9597" # TODO: automate write when foundry upgrades
 default_num_signers = 10
+supported_orchestrators = []
 # LayerZero configuration (copied from Base Sepolia for testing)
 # TODO: Set correct addresses here.
 layerzero_settler_address = "0x4225041FF3DB1C7d7a1029406bB80C7298767aca"
@@ -79,6 +80,7 @@ target_balance = 1000000000000000 # 0.001 ether
 # SimpleFunder configuration
 simple_funder_address = "0x5e6c8c24A53275e2C6C3DC5f1c5C027Ec13439Ba"
 default_num_signers = 10
+supported_orchestrators = []
 # LayerZero configuration 
 layerzero_settler_address = "0x4225041FF3DB1C7d7a1029406bB80C7298767aca"
 layerzero_send_uln302 = "0xC1868e054425D378095A003EcbA3823a5D0135C9"
@@ -117,8 +119,8 @@ target_balance = 10000000000000000 # 0.01 ether
 contracts = ["ALL"]  # Deploy all contracts
 # SimpleFunder configuration
 simple_funder_address = "0x2AD8F6a3bB1126a777606eaFa9da9b95530d9597" 
-
 default_num_signers = 10
+supported_orchestrators = []
 # LayerZero configuration
 layerzero_settler_address = "0x4225041FF3DB1C7d7a1029406bB80C7298767aca"
 layerzero_send_uln302 = "0xB31D2cb502E25B30C651842C7C3293c51Fe6d16f"

--- a/deploy/config.toml
+++ b/deploy/config.toml
@@ -35,7 +35,7 @@ contracts = ["LayerZeroSettler"]
 # SimpleFunder configuration
 simple_funder_address = "0x2AD8F6a3bB1126a777606eaFa9da9b95530d9597" # TODO: automate write when foundry upgrades
 default_num_signers = 10
-supported_orchestrators = []
+supported_orchestrators = ["0xEd7c1e839381c489Dcd1ED3CE1B0e79DaE714f77"]
 # LayerZero configuration (copied from Base Sepolia for testing)
 # TODO: Set correct addresses here.
 layerzero_settler_address = "0x4225041FF3DB1C7d7a1029406bB80C7298767aca"
@@ -78,9 +78,9 @@ contracts = ["ALL"]
 target_balance = 1000000000000000 # 0.001 ether
 
 # SimpleFunder configuration
-simple_funder_address = "0x5e6c8c24A53275e2C6C3DC5f1c5C027Ec13439Ba"
+simple_funder_address = "0x09F6eF9525efAdb6167dFe71fFcfbE306De07988"
 default_num_signers = 10
-supported_orchestrators = []
+supported_orchestrators = ["0xEd7c1e839381c489Dcd1ED3CE1B0e79DaE714f77"]
 # LayerZero configuration 
 layerzero_settler_address = "0x4225041FF3DB1C7d7a1029406bB80C7298767aca"
 layerzero_send_uln302 = "0xC1868e054425D378095A003EcbA3823a5D0135C9"
@@ -120,7 +120,7 @@ contracts = ["ALL"]  # Deploy all contracts
 # SimpleFunder configuration
 simple_funder_address = "0x2AD8F6a3bB1126a777606eaFa9da9b95530d9597" 
 default_num_signers = 10
-supported_orchestrators = []
+supported_orchestrators = ["0xEd7c1e839381c489Dcd1ED3CE1B0e79DaE714f77"]
 # LayerZero configuration
 layerzero_settler_address = "0x4225041FF3DB1C7d7a1029406bB80C7298767aca"
 layerzero_send_uln302 = "0xB31D2cb502E25B30C651842C7C3293c51Fe6d16f"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ithaca-account",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "EIP-7702 account for Ithaca Porto",
   "license": "MIT",
   "scripts": {

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -26,18 +26,10 @@ contract DeployAllScript is Script {
         accountProxy = LibEIP7702.deployProxy(accountImplementation, address(0));
         simulator = address(new Simulator());
 
-        address[] memory orchestrators = vm.envOr("ORCHESTRATORS", ",", new address[](0));
-        address[] memory newOrchestrators = new address[](orchestrators.length + 1);
-        for (uint256 i; i < orchestrators.length; i++) {
-            newOrchestrators[i] = orchestrators[i];
-        }
-        newOrchestrators[orchestrators.length] = orchestrator;
-
-        funder = address(
-            new SimpleFunder(
-                vm.envAddress("FUNDER"), newOrchestrators, vm.envAddress("FUNDER_OWNER")
-            )
-        );
+        funder = address(new SimpleFunder(vm.envAddress("FUNDER"), msg.sender));
+        address[] memory ocs = new address[](1);
+        ocs[0] = address(orchestrator);
+        SimpleFunder(payable(funder)).setOrchestrators(ocs, true);
         simpleSettler = address(new SimpleSettler(vm.envAddress("SETTLER_OWNER")));
         escrow = address(new Escrow());
 

--- a/script/DeployAll.s.sol
+++ b/script/DeployAll.s.sol
@@ -25,9 +25,17 @@ contract DeployAllScript is Script {
         accountImplementation = address(new IthacaAccount(address(orchestrator)));
         accountProxy = LibEIP7702.deployProxy(accountImplementation, address(0));
         simulator = address(new Simulator());
+
+        address[] memory orchestrators = vm.envOr("ORCHESTRATORS", ",", new address[](0));
+        address[] memory newOrchestrators = new address[](orchestrators.length + 1);
+        for (uint256 i; i < orchestrators.length; i++) {
+            newOrchestrators[i] = orchestrators[i];
+        }
+        newOrchestrators[orchestrators.length] = orchestrator;
+
         funder = address(
             new SimpleFunder(
-                vm.envAddress("FUNDER"), address(orchestrator), vm.envAddress("FUNDER_OWNER")
+                vm.envAddress("FUNDER"), newOrchestrators, vm.envAddress("FUNDER_OWNER")
             )
         );
         simpleSettler = address(new SimpleSettler(vm.envAddress("SETTLER_OWNER")));

--- a/src/SimpleFunder.sol
+++ b/src/SimpleFunder.sol
@@ -42,12 +42,9 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
     // Constructor
     ////////////////////////////////////////////////////////////////////////
 
-    constructor(address _funder, address[] memory _orchestrators, address _owner) {
+    constructor(address _funder, address _owner) {
         funder = _funder;
         _initializeOwner(_owner);
-        for (uint256 i = 0; i < _orchestrators.length; i++) {
-            orchestrators[_orchestrators[i]] = true;
-        }
     }
 
     /// @dev For EIP712.
@@ -59,7 +56,7 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
         returns (string memory name, string memory version)
     {
         name = "SimpleFunder";
-        version = "0.1.4";
+        version = "0.1.5";
     }
 
     ////////////////////////////////////////////////////////////////////////
@@ -106,8 +103,10 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
         funder = newFunder;
     }
 
-    function setOrchestrator(address oc, bool val) external onlyOwner {
-        orchestrators[oc] = val;
+    function setOrchestrators(address[] memory ocs, bool val) external onlyOwner {
+        for (uint256 i; i < ocs.length; ++i) {
+            orchestrators[ocs[i]] = val;
+        }
     }
 
     /// @dev Allows the owner to set the gas wallets.

--- a/src/SimpleFunder.sol
+++ b/src/SimpleFunder.sol
@@ -28,12 +28,11 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
     error InvalidNonce();
     error DeadlineExpired();
 
-    address public immutable ORCHESTRATOR;
-
     address public funder;
 
     mapping(address => bool) public gasWallets;
     mapping(uint256 => bool) public nonces;
+    mapping(address => bool) public orchestrators;
 
     bytes32 constant WITHDRAWAL_TYPE_HASH = keccak256(
         "Withdrawal(address token,address recipient,uint256 amount,uint256 deadline,uint256 nonce)"
@@ -43,10 +42,12 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
     // Constructor
     ////////////////////////////////////////////////////////////////////////
 
-    constructor(address _funder, address _orchestrator, address _owner) {
+    constructor(address _funder, address[] memory _orchestrators, address _owner) {
         funder = _funder;
-        ORCHESTRATOR = _orchestrator;
         _initializeOwner(_owner);
+        for (uint256 i = 0; i < _orchestrators.length; i++) {
+            orchestrators[_orchestrators[i]] = true;
+        }
     }
 
     /// @dev For EIP712.
@@ -105,6 +106,10 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
         funder = newFunder;
     }
 
+    function setOrchestrator(address oc, bool val) external onlyOwner {
+        orchestrators[oc] = val;
+    }
+
     /// @dev Allows the owner to set the gas wallets.
     function setGasWallet(address[] memory wallets, bool isGasWallet) external onlyOwner {
         for (uint256 i; i < wallets.length; ++i) {
@@ -116,12 +121,22 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
     // Orchestrator Functions
     ////////////////////////////////////////////////////////////////////////
 
+    function fund(
+        address,
+        bytes32 digest,
+        ICommon.Transfer[] memory transfers,
+        bytes memory funderSignature
+    ) external override {
+        return fund(digest, transfers, funderSignature);
+    }
+
     /// @dev Allows the orchestrator to fund an account.
     /// The `digest` includes the intent nonce and the transfers.
     function fund(bytes32 digest, ICommon.Transfer[] memory transfers, bytes memory funderSignature)
-        external
+        public
+        override
     {
-        if (msg.sender != ORCHESTRATOR) {
+        if (!orchestrators[msg.sender]) {
             revert OnlyOrchestrator();
         }
 
@@ -140,12 +155,11 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
         uint256 i = 0;
         if (transfers[0].token == address(0)) {
             // Since we know the orchestrator implements a clean `Receive()` we don't need to check if the call was successful.
-            (bool success,) = ORCHESTRATOR.call{value: transfers[0].amount}("");
+            (bool success,) = msg.sender.call{value: transfers[0].amount}("");
             (success);
             i++;
         }
 
-        address orchestrator = ORCHESTRATOR;
         for (i; i < transfers.length; ++i) {
             address token = transfers[i].token;
             uint256 amount = transfers[i].amount;
@@ -154,7 +168,7 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
                 let m := mload(0x40)
                 mstore(m, 0xdd62ed3e) // `allowance(address,address)`.
                 mstore(add(m, 0x20), address())
-                mstore(add(m, 0x40), orchestrator)
+                mstore(add(m, 0x40), caller())
                 mstore(0, 0)
                 // Orchestrator checks for token transfer success, so we don't need to check it here.
                 pop(call(gas(), token, 0, add(m, 0x1c), 0x44, 0x00, 0x20))
@@ -162,7 +176,7 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
                 let allowance := mload(0x00)
                 if gt(amount, allowance) {
                     mstore(m, 0x095ea7b3) // `approve(address,uint256)`.
-                    mstore(add(m, 0x20), orchestrator)
+                    mstore(add(m, 0x20), caller())
                     mstore(add(m, 0x40), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) // type(uint256).max
                     // Orchestrator checks for token transfer success, so we don't need to check it here.
                     pop(call(gas(), token, 0, add(m, 0x1c), 0x44, 0x00, 0x00))

--- a/src/interfaces/IFunder.sol
+++ b/src/interfaces/IFunder.sol
@@ -3,7 +3,17 @@ pragma solidity ^0.8.0;
 
 import {ICommon} from "./ICommon.sol";
 
-interface IFunder {
+interface IFunderV4 {
+    /// @dev Should fund the account with the given transfers, after verifying the signature.
+    function fund(
+        address account,
+        bytes32 digest,
+        ICommon.Transfer[] memory transfers,
+        bytes memory funderSignature
+    ) external;
+}
+
+interface IFunder is IFunderV4 {
     /// @dev Checks if fund transfers are valid given a funderSignature.
     /// @dev Funder implementations must revert if the signature is invalid.
     function fund(bytes32 digest, ICommon.Transfer[] memory transfers, bytes memory funderSignature)

--- a/test/Orchestrator.t.sol
+++ b/test/Orchestrator.t.sol
@@ -1301,10 +1301,13 @@ contract OrchestratorTest is BaseTest {
     function testMultiChainIntent() public {
         _TestMultiChainIntentTemps memory t;
 
+        address[] memory ocs = new address[](1);
+        ocs[0] = address(oc);
+
         // Initialize core test data
         t.funderPrivateKey = _randomPrivateKey();
         t.settlementOracle = makeAddr("SETTLEMENT_ORACLE");
-        t.funder = new SimpleFunder(vm.addr(t.funderPrivateKey), address(oc), address(this));
+        t.funder = new SimpleFunder(vm.addr(t.funderPrivateKey), ocs, address(this));
         t.settler = new SimpleSettler(t.settlementOracle);
         t.gasWallet = makeAddr("GAS_WALLET");
         t.relay = makeAddr("RELAY");

--- a/test/Orchestrator.t.sol
+++ b/test/Orchestrator.t.sol
@@ -1307,7 +1307,9 @@ contract OrchestratorTest is BaseTest {
         // Initialize core test data
         t.funderPrivateKey = _randomPrivateKey();
         t.settlementOracle = makeAddr("SETTLEMENT_ORACLE");
-        t.funder = new SimpleFunder(vm.addr(t.funderPrivateKey), ocs, address(this));
+        t.funder = new SimpleFunder(vm.addr(t.funderPrivateKey), address(this));
+
+        t.funder.setOrchestrators(ocs, true);
         t.settler = new SimpleSettler(t.settlementOracle);
         t.gasWallet = makeAddr("GAS_WALLET");
         t.relay = makeAddr("RELAY");

--- a/test/SimpleFunder.t.sol
+++ b/test/SimpleFunder.t.sol
@@ -34,9 +34,11 @@ contract SimpleFunderTest is Test {
         owner = vm.addr(ownerPrivateKey);
         recipient = makeAddr("recipient");
 
+        simpleFunder = new SimpleFunder(funder, owner);
+        vm.prank(owner);
         address[] memory ocs = new address[](1);
-        ocs[0] = address(orchestrator);
-        simpleFunder = new SimpleFunder(funder, ocs, owner);
+        ocs[0] = orchestrator;
+        simpleFunder.setOrchestrators(ocs, true);
         token = new MockPaymentToken();
 
         // Fund the SimpleFunder with tokens

--- a/test/SimpleFunder.t.sol
+++ b/test/SimpleFunder.t.sol
@@ -34,7 +34,9 @@ contract SimpleFunderTest is Test {
         owner = vm.addr(ownerPrivateKey);
         recipient = makeAddr("recipient");
 
-        simpleFunder = new SimpleFunder(funder, orchestrator, owner);
+        address[] memory ocs = new address[](1);
+        ocs[0] = address(orchestrator);
+        simpleFunder = new SimpleFunder(funder, ocs, owner);
         token = new MockPaymentToken();
 
         // Fund the SimpleFunder with tokens


### PR DESCRIPTION
# SimpleFunder: Support multiple orchestrators

  SimpleFunder now supports multiple orchestrators instead of a single immutable
  orchestrator. The `ORCHESTRATOR` immutable field has been replaced with an
  `orchestrators` mapping that can be managed by the contract owner.

  Deployment scripts updated to configure orchestrators after SimpleFunder deployment
   using the new `supported_orchestrators` config field.
   
   
   @kuyziss @jenpaff @laibe There is an additional config variable in the FundSigners script, which you have to set with all orchestrators, including the latest deployments.
   This step has to be completed before running anything interop related.