### PR TITLE
fix(GuardedExecutor): use execute-specific super admin error in setCallChecker

### DIFF
--- a/src/GuardedExecutor.sol
+++ b/src/GuardedExecutor.sol
@@ -400,7 +400,7 @@ abstract contract GuardedExecutor is ERC7821 {
         checkKeyHashIsNonZero(keyHash)
     {
         if (keyHash != ANY_KEYHASH) {
-            if (_isSuperAdmin(keyHash)) revert SuperAdminCanSpendAnything();
+            if (_isSuperAdmin(keyHash)) revert SuperAdminCanExecuteEverything();
         }
 
         // It is ok even if we don't check for `_isSelfExecute` here, as we will still


### PR DESCRIPTION
Replace SuperAdminCanSpendAnything with SuperAdminCanExecuteEverything in setCallChecker.
Call checkers govern execution authorization, not spend limits. Super-admin keys already bypass execution checks via canExecute, so attempting to configure a call checker for them is nonsensical in the execution domain. Using the execute-specific error aligns this guard with setCanExecute and clarifies intent.