### PR TITLE
docs: clarify IIthacaAccount.pay NatSpec; add paymentAmount and reorder params

### DIFF
--- a/src/interfaces/IIthacaAccount.sol
+++ b/src/interfaces/IIthacaAccount.sol
@@ -6,10 +6,12 @@ import {ICommon} from "../interfaces/ICommon.sol";
 /// @title IIthacaAccount
 /// @notice Interface for the Account contract
 interface IIthacaAccount is ICommon {
-    /// @dev Pays `paymentAmount` of `paymentToken` to the `paymentRecipient`.
-    /// @param keyHash The hash of the key used to authorize the operation
-    /// @param encodedIntent The encoded user operation
-    /// @param intentDigest The digest of the user operation
+    /// @dev Pays `paymentAmount` of the Intent's `paymentToken` to the Intent's `paymentRecipient`.
+    /// `paymentToken` and `paymentRecipient` are read from `encodedIntent` (ABI-encoded `ICommon.Intent`).
+    /// @param paymentAmount The amount to pay.
+    /// @param keyHash The hash of the key used to authorize the operation.
+    /// @param intentDigest The digest of the user operation.
+    /// @param encodedIntent ABI-encoded `ICommon.Intent`.
     function pay(
         uint256 paymentAmount,
         bytes32 keyHash,


### PR DESCRIPTION
- Clarify that paymentToken and paymentRecipient come from encodedIntent (ABI-encoded ICommon.Intent).
- Add missing @param paymentAmount and reorder @param tags to match the function signature.
- Replace vague “encoded user operation” with “ABI-encoded ICommon.Intent”.
- These changes are necessary to eliminate documentation inconsistency, prevent integrator confusion, and align comments with the actual implementation in Orchestrator/IthacaAccount.