### PR TITLE
feat(ci): auto-assign PR to author

### DIFF
--- a/.github/workflows/auto-assign.yaml
+++ b/.github/workflows/auto-assign.yaml
@@ -1,27 +1,47 @@
-name: Auto Assign PR
+name: Auto Assign PR to Author
 
 on:
   pull_request:
-    types: [opened]
+    types: [opened, reopened]
 
 jobs:
   auto-assign:
-    runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
+    runs-on: ubuntu-latest
     steps:
       - name: Auto assign PR to author
+        if: >
+          github.event.pull_request.user.type != 'Bot' &&
+          (
+            github.event.pull_request.author_association == 'MEMBER' ||
+            github.event.pull_request.author_association == 'OWNER'  ||
+            github.event.pull_request.author_association == 'COLLABORATOR'
+          )
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request;
-            const author = pr.user.login;
-            
-            await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: pr.number,
-              assignees: [author]
-            });
-            
-            console.log(`Successfully assigned PR #${pr.number} to @${author}`);
+            const pr = context.payload.pull_request
+            const prAuthor = pr.user.login
+
+            console.log(`PR #${pr.number} author: ${prAuthor}`)
+            console.log(`Current assignees: ${pr.assignees.map(a => a.login).join(', ') || 'none'}`)
+
+            if (pr.assignees && pr.assignees.length > 0) {
+              console.log('PR already has assignees, skipping')
+              return
+            }
+
+            try {
+              await github.rest.issues.addAssignees({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: pr.number,
+                assignees: [prAuthor]
+              })
+              console.log(`Successfully assigned PR #${pr.number} to ${prAuthor}`)
+            } catch (error) {
+              console.error(`Failed to assign PR: ${error.message}`)
+              throw error
+            }


### PR DESCRIPTION
saw [this](https://github.com/ithacaxyz/account/compare/5be16262539c...d0a4e6fbf2af) on slack notifications. We did the same thing in the relay repo. This PR:
- handles permissions,
- assigns the PR conditionally: if already assigned, or author is a bot, or author is external, then skip,
- runs on opened and reopened PRs (vs. only opened).