### PR TITLE
fix incorrect comment

### DIFF
--- a/src/SimpleFunder.sol
+++ b/src/SimpleFunder.sol
@@ -182,7 +182,7 @@ contract SimpleFunder is EIP712, Ownable, IFunder {
                 if gt(amount, allowance) {
                     mstore(m, 0x095ea7b3) // `approve(address,uint256)`.
                     mstore(add(m, 0x20), caller())
-                    mstore(add(m, 0x40), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) // type(uint256).max
+                    mstore(add(m, 0x40), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF) // 20-byte all-ones sentinel (2^160-1), not uint256 max
                     // Orchestrator checks for token transfer success, so we don't need to check it here.
                     pop(call(gas(), token, 0, add(m, 0x1c), 0x44, 0x00, 0x00))
                 }


### PR DESCRIPTION
Update inline comment to reflect that the approval amount literal is a 20-byte all-ones value (2^160−1), not type(uint256).max