### PR TITLE
fix: remove unused InvalidEndpointCall error from IOAppCore

### DIFF
--- a/src/vendor/layerzero/interfaces/IOAppCore.sol
+++ b/src/vendor/layerzero/interfaces/IOAppCore.sol
@@ -2,9 +2,8 @@
 
 pragma solidity ^0.8.20;
 
-import {
-    ILayerZeroEndpointV2
-} from "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
+import {ILayerZeroEndpointV2} from
+    "@layerzerolabs/lz-evm-protocol-v2/contracts/interfaces/ILayerZeroEndpointV2.sol";
 
 /**
  * @title IOAppCore
@@ -13,7 +12,6 @@ interface IOAppCore {
     // Custom error messages
     error OnlyPeer(uint32 eid, bytes32 sender);
     error NoPeer(uint32 eid);
-    error InvalidEndpointCall();
     error InvalidDelegate();
 
     // Event emitted when a peer (OApp) is set for a corresponding endpoint


### PR DESCRIPTION
Remove unused InvalidEndpointCall error declaration from IOAppCore interface.
The error was declared but never used in any implementation or test files.